### PR TITLE
release: prepare 0.3.0 scoped execution

### DIFF
--- a/.agents/skills/black_ruff_mypy/SKILL.md
+++ b/.agents/skills/black_ruff_mypy/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: black_ruff_mypy
+description: Formateador, linter ultra-rápido y type checking estático para garantizar calidad del código Python
+type: Tool
+priority: Esencial
+mode: Self-hosted
+---
+
+# black_ruff_mypy
+
+Tres herramientas complementarias que se ejecutan juntas en cada commit y en CI para mantener la calidad del código Python sin debate entre developers.
+
+## When to use
+
+Configurar en pre-commit hooks desde el primer commit. Ejecutar también en CI como gate obligatorio antes de merge.
+
+## Instructions
+
+1. Instalar: `pip install black ruff mypy`
+2. Configurar en `pyproject.toml`:
+
+   ```toml
+   [tool.black]
+   line-length = 100
+   target-version = ["py311"]
+
+   [tool.ruff]
+   line-length = 100
+   select = ["E", "F", "I", "N", "W", "UP", "S", "B"]
+   ignore = ["S101"]  # allow assert in tests
+
+   [tool.mypy]
+   python_version = "3.11"
+   strict = true
+   ignore_missing_imports = true
+   plugins = ["pydantic.mypy"]
+   ```
+
+3. Añadir a `.pre-commit-config.yaml`:
+   ```yaml
+   repos:
+     - repo: https://github.com/psf/black
+       rev: 23.12.0
+       hooks: [{id: black}]
+     - repo: https://github.com/astral-sh/ruff-pre-commit
+       rev: v0.1.9
+       hooks: [{id: ruff, args: [--fix]}]
+     - repo: https://github.com/pre-commit/mirrors-mypy
+       rev: v1.8.0
+       hooks: [{id: mypy, additional_dependencies: [pydantic, types-redis]}]
+   ```
+4. Instalar hooks: `pre-commit install`.
+5. En CI: `ruff check . && black --check . && mypy backend/`.
+
+## Notes
+
+- Black reformatea automáticamente — los developers aceptan el formato sin discutir estilo.
+- Ruff en modo `--fix` corrige automáticamente los errores que puede (imports desordenados, unused imports).
+- mypy `strict=true` requiere type annotations en todo el código — es estricto pero previene bugs sutiles en async code.
+- Ruff reemplaza Flake8, isort, pydocstyle y más — es 100x más rápido que las alternativas.

--- a/.agents/skills/find-skills/SKILL.md
+++ b/.agents/skills/find-skills/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`bunx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `bunx skills find [query]` - Search for skills interactively or by keyword
+- `bunx skills add <package>` - Install a skill from GitHub or other sources
+- `bunx skills check` - Check for skill updates
+- `bunx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+bunx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `bunx skills find react performance`
+- User asks "can you help me with PR reviews?" → `bunx skills find pr review`
+- User asks "I need to create a changelog" → `bunx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+bunx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+bunx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `bunx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+bunx skills init my-xyz-skill
+```

--- a/.agents/skills/gh-cli/SKILL.md
+++ b/.agents/skills/gh-cli/SKILL.md
@@ -1,0 +1,2187 @@
+---
+name: gh-cli
+description: GitHub CLI (gh) comprehensive reference for repositories, issues, pull requests, Actions, projects, releases, gists, codespaces, organizations, extensions, and all GitHub operations from the command line.
+---
+
+# GitHub CLI (gh)
+
+Comprehensive reference for GitHub CLI (gh) - work seamlessly with GitHub from the command line.
+
+**Version:** 2.85.0 (current as of January 2026)
+
+## Prerequisites
+
+### Installation
+
+```bash
+# macOS
+brew install gh
+
+# Linux
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update
+sudo apt install gh
+
+# Windows
+winget install --id GitHub.cli
+
+# Verify installation
+gh --version
+```
+
+### Authentication
+
+```bash
+# Interactive login (default: github.com)
+gh auth login
+
+# Login with specific hostname
+gh auth login --hostname enterprise.internal
+
+# Login with token
+gh auth login --with-token < mytoken.txt
+
+# Check authentication status
+gh auth status
+
+# Switch accounts
+gh auth switch --hostname github.com --user username
+
+# Logout
+gh auth logout --hostname github.com --user username
+```
+
+### Setup Git Integration
+
+```bash
+# Configure git to use gh as credential helper
+gh auth setup-git
+
+# View active token
+gh auth token
+
+# Refresh authentication scopes
+gh auth refresh --scopes write:org,read:public_key
+```
+
+## CLI Structure
+
+```
+gh                          # Root command
+├── auth                    # Authentication
+│   ├── login
+│   ├── logout
+│   ├── refresh
+│   ├── setup-git
+│   ├── status
+│   ├── switch
+│   └── token
+├── browse                  # Open in browser
+├── codespace               # GitHub Codespaces
+│   ├── code
+│   ├── cp
+│   ├── create
+│   ├── delete
+│   ├── edit
+│   ├── jupyter
+│   ├── list
+│   ├── logs
+│   ├── ports
+│   ├── rebuild
+│   ├── ssh
+│   ├── stop
+│   └── view
+├── gist                    # Gists
+│   ├── clone
+│   ├── create
+│   ├── delete
+│   ├── edit
+│   ├── list
+│   ├── rename
+│   └── view
+├── issue                   # Issues
+│   ├── create
+│   ├── list
+│   ├── status
+│   ├── close
+│   ├── comment
+│   ├── delete
+│   ├── develop
+│   ├── edit
+│   ├── lock
+│   ├── pin
+│   ├── reopen
+│   ├── transfer
+│   ├── unlock
+│   └── view
+├── org                     # Organizations
+│   └── list
+├── pr                      # Pull Requests
+│   ├── create
+│   ├── list
+│   ├── status
+│   ├── checkout
+│   ├── checks
+│   ├── close
+│   ├── comment
+│   ├── diff
+│   ├── edit
+│   ├── lock
+│   ├── merge
+│   ├── ready
+│   ├── reopen
+│   ├── revert
+│   ├── review
+│   ├── unlock
+│   ├── update-branch
+│   └── view
+├── project                 # Projects
+│   ├── close
+│   ├── copy
+│   ├── create
+│   ├── delete
+│   ├── edit
+│   ├── field-create
+│   ├── field-delete
+│   ├── field-list
+│   ├── item-add
+│   ├── item-archive
+│   ├── item-create
+│   ├── item-delete
+│   ├── item-edit
+│   ├── item-list
+│   ├── link
+│   ├── list
+│   ├── mark-template
+│   ├── unlink
+│   └── view
+├── release                 # Releases
+│   ├── create
+│   ├── list
+│   ├── delete
+│   ├── delete-asset
+│   ├── download
+│   ├── edit
+│   ├── upload
+│   ├── verify
+│   ├── verify-asset
+│   └── view
+├── repo                    # Repositories
+│   ├── create
+│   ├── list
+│   ├── archive
+│   ├── autolink
+│   ├── clone
+│   ├── delete
+│   ├── deploy-key
+│   ├── edit
+│   ├── fork
+│   ├── gitignore
+│   ├── license
+│   ├── rename
+│   ├── set-default
+│   ├── sync
+│   ├── unarchive
+│   └── view
+├── cache                   # Actions caches
+│   ├── delete
+│   └── list
+├── run                     # Workflow runs
+│   ├── cancel
+│   ├── delete
+│   ├── download
+│   ├── list
+│   ├── rerun
+│   ├── view
+│   └── watch
+├── workflow                # Workflows
+│   ├── disable
+│   ├── enable
+│   ├── list
+│   ├── run
+│   └── view
+├── agent-task              # Agent tasks
+├── alias                   # Command aliases
+│   ├── delete
+│   ├── import
+│   ├── list
+│   └── set
+├── api                     # API requests
+├── attestation             # Artifact attestations
+│   ├── download
+│   ├── trusted-root
+│   └── verify
+├── completion              # Shell completion
+├── config                  # Configuration
+│   ├── clear-cache
+│   ├── get
+│   ├── list
+│   └── set
+├── extension               # Extensions
+│   ├── browse
+│   ├── create
+│   ├── exec
+│   ├── install
+│   ├── list
+│   ├── remove
+│   ├── search
+│   └── upgrade
+├── gpg-key                 # GPG keys
+│   ├── add
+│   ├── delete
+│   └── list
+├── label                   # Labels
+│   ├── clone
+│   ├── create
+│   ├── delete
+│   ├── edit
+│   └── list
+├── preview                 # Preview features
+├── ruleset                 # Rulesets
+│   ├── check
+│   ├── list
+│   └── view
+├── search                  # Search
+│   ├── code
+│   ├── commits
+│   ├── issues
+│   ├── prs
+│   └── repos
+├── secret                  # Secrets
+│   ├── delete
+│   ├── list
+│   └── set
+├── ssh-key                 # SSH keys
+│   ├── add
+│   ├── delete
+│   └── list
+├── status                  # Status overview
+└── variable                # Variables
+    ├── delete
+    ├── get
+    ├── list
+    └── set
+```
+
+## Configuration
+
+### Global Configuration
+
+```bash
+# List all configuration
+gh config list
+
+# Get specific configuration value
+gh config list git_protocol
+gh config get editor
+
+# Set configuration value
+gh config set editor vim
+gh config set git_protocol ssh
+gh config set prompt disabled
+gh config set pager "less -R"
+
+# Clear configuration cache
+gh config clear-cache
+```
+
+### Environment Variables
+
+```bash
+# GitHub token (for automation)
+export GH_TOKEN=ghp_xxxxxxxxxxxx
+
+# GitHub hostname
+export GH_HOST=github.com
+
+# Disable prompts
+export GH_PROMPT_DISABLED=true
+
+# Custom editor
+export GH_EDITOR=vim
+
+# Custom pager
+export GH_PAGER=less
+
+# HTTP timeout
+export GH_TIMEOUT=30
+
+# Custom repository (override default)
+export GH_REPO=owner/repo
+
+# Custom git protocol
+export GH_ENTERPRISE_HOSTNAME=hostname
+```
+
+## Authentication (gh auth)
+
+### Login
+
+```bash
+# Interactive login
+gh auth login
+
+# Web-based authentication
+gh auth login --web
+
+# With clipboard for OAuth code
+gh auth login --web --clipboard
+
+# With specific git protocol
+gh auth login --git-protocol ssh
+
+# With custom hostname (GitHub Enterprise)
+gh auth login --hostname enterprise.internal
+
+# Login with token from stdin
+gh auth login --with-token < token.txt
+
+# Insecure storage (plain text)
+gh auth login --insecure-storage
+```
+
+### Status
+
+```bash
+# Show all authentication status
+gh auth status
+
+# Show active account only
+gh auth status --active
+
+# Show specific hostname
+gh auth status --hostname github.com
+
+# Show token in output
+gh auth status --show-token
+
+# JSON output
+gh auth status --json hosts
+
+# Filter with jq
+gh auth status --json hosts --jq '.hosts | add'
+```
+
+### Switch Accounts
+
+```bash
+# Interactive switch
+gh auth switch
+
+# Switch to specific user/host
+gh auth switch --hostname github.com --user monalisa
+```
+
+### Token
+
+```bash
+# Print authentication token
+gh auth token
+
+# Token for specific host/user
+gh auth token --hostname github.com --user monalisa
+```
+
+### Refresh
+
+```bash
+# Refresh credentials
+gh auth refresh
+
+# Add scopes
+gh auth refresh --scopes write:org,read:public_key
+
+# Remove scopes
+gh auth refresh --remove-scopes delete_repo
+
+# Reset to default scopes
+gh auth refresh --reset-scopes
+
+# With clipboard
+gh auth refresh --clipboard
+```
+
+### Setup Git
+
+```bash
+# Setup git credential helper
+gh auth setup-git
+
+# Setup for specific host
+gh auth setup-git --hostname enterprise.internal
+
+# Force setup even if host not known
+gh auth setup-git --hostname enterprise.internal --force
+```
+
+## Browse (gh browse)
+
+```bash
+# Open repository in browser
+gh browse
+
+# Open specific path
+gh browse script/
+gh browse main.go:312
+
+# Open issue or PR
+gh browse 123
+
+# Open commit
+gh browse 77507cd94ccafcf568f8560cfecde965fcfa63
+
+# Open with specific branch
+gh browse main.go --branch bug-fix
+
+# Open different repository
+gh browse --repo owner/repo
+
+# Open specific pages
+gh browse --actions       # Actions tab
+gh browse --projects      # Projects tab
+gh browse --releases      # Releases tab
+gh browse --settings      # Settings page
+gh browse --wiki          # Wiki page
+
+# Print URL instead of opening
+gh browse --no-browser
+```
+
+## Repositories (gh repo)
+
+### Create Repository
+
+```bash
+# Create new repository
+gh repo create my-repo
+
+# Create with description
+gh repo create my-repo --description "My awesome project"
+
+# Create public repository
+gh repo create my-repo --public
+
+# Create private repository
+gh repo create my-repo --private
+
+# Create with homepage
+gh repo create my-repo --homepage https://example.com
+
+# Create with license
+gh repo create my-repo --license mit
+
+# Create with gitignore
+gh repo create my-repo --gitignore python
+
+# Initialize as template repository
+gh repo create my-repo --template
+
+# Create repository in organization
+gh repo create org/my-repo
+
+# Create without cloning locally
+gh repo create my-repo --source=.
+
+# Disable issues
+gh repo create my-repo --disable-issues
+
+# Disable wiki
+gh repo create my-repo --disable-wiki
+```
+
+### Clone Repository
+
+```bash
+# Clone repository
+gh repo clone owner/repo
+
+# Clone to specific directory
+gh repo clone owner/repo my-directory
+
+# Clone with different branch
+gh repo clone owner/repo --branch develop
+```
+
+### List Repositories
+
+```bash
+# List all repositories
+gh repo list
+
+# List repositories for owner
+gh repo list owner
+
+# Limit results
+gh repo list --limit 50
+
+# Public repositories only
+gh repo list --public
+
+# Source repositories only (not forks)
+gh repo list --source
+
+# JSON output
+gh repo list --json name,visibility,owner
+
+# Table output
+gh repo list --limit 100 | tail -n +2
+
+# Filter with jq
+gh repo list --json name --jq '.[].name'
+```
+
+### View Repository
+
+```bash
+# View repository details
+gh repo view
+
+# View specific repository
+gh repo view owner/repo
+
+# JSON output
+gh repo view --json name,description,defaultBranchRef
+
+# View in browser
+gh repo view --web
+```
+
+### Edit Repository
+
+```bash
+# Edit description
+gh repo edit --description "New description"
+
+# Set homepage
+gh repo edit --homepage https://example.com
+
+# Change visibility
+gh repo edit --visibility private
+gh repo edit --visibility public
+
+# Enable/disable features
+gh repo edit --enable-issues
+gh repo edit --disable-issues
+gh repo edit --enable-wiki
+gh repo edit --disable-wiki
+gh repo edit --enable-projects
+gh repo edit --disable-projects
+
+# Set default branch
+gh repo edit --default-branch main
+
+# Rename repository
+gh repo rename new-name
+
+# Archive repository
+gh repo archive
+gh repo unarchive
+```
+
+### Delete Repository
+
+```bash
+# Delete repository
+gh repo delete owner/repo
+
+# Confirm without prompt
+gh repo delete owner/repo --yes
+```
+
+### Fork Repository
+
+```bash
+# Fork repository
+gh repo fork owner/repo
+
+# Fork to organization
+gh repo fork owner/repo --org org-name
+
+# Clone after forking
+gh repo fork owner/repo --clone
+
+# Remote name for fork
+gh repo fork owner/repo --remote-name upstream
+```
+
+### Sync Fork
+
+```bash
+# Sync fork with upstream
+gh repo sync
+
+# Sync specific branch
+gh repo sync --branch feature
+
+# Force sync
+gh repo sync --force
+```
+
+### Set Default Repository
+
+```bash
+# Set default repository for current directory
+gh repo set-default
+
+# Set default explicitly
+gh repo set-default owner/repo
+
+# Unset default
+gh repo set-default --unset
+```
+
+### Repository Autolinks
+
+```bash
+# List autolinks
+gh repo autolink list
+
+# Add autolink
+gh repo autolink add \
+  --key-prefix JIRA- \
+  --url-template https://jira.example.com/browse/<num>
+
+# Delete autolink
+gh repo autolink delete 12345
+```
+
+### Repository Deploy Keys
+
+```bash
+# List deploy keys
+gh repo deploy-key list
+
+# Add deploy key
+gh repo deploy-key add ~/.ssh/id_rsa.pub \
+  --title "Production server" \
+  --read-only
+
+# Delete deploy key
+gh repo deploy-key delete 12345
+```
+
+### Gitignore and License
+
+```bash
+# View gitignore template
+gh repo gitignore
+
+# View license template
+gh repo license mit
+
+# License with full name
+gh repo license mit --fullname "John Doe"
+```
+
+## Issues (gh issue)
+
+### Create Issue
+
+```bash
+# Create issue interactively
+gh issue create
+
+# Create with title
+gh issue create --title "Bug: Login not working"
+
+# Create with title and body
+gh issue create \
+  --title "Bug: Login not working" \
+  --body "Steps to reproduce..."
+
+# Create with body from file
+gh issue create --body-file issue.md
+
+# Create with labels
+gh issue create --title "Fix bug" --labels bug,high-priority
+
+# Create with assignees
+gh issue create --title "Fix bug" --assignee user1,user2
+
+# Create in specific repository
+gh issue create --repo owner/repo --title "Issue title"
+
+# Create issue from web
+gh issue create --web
+```
+
+### List Issues
+
+```bash
+# List all open issues
+gh issue list
+
+# List all issues (including closed)
+gh issue list --state all
+
+# List closed issues
+gh issue list --state closed
+
+# Limit results
+gh issue list --limit 50
+
+# Filter by assignee
+gh issue list --assignee username
+gh issue list --assignee @me
+
+# Filter by labels
+gh issue list --labels bug,enhancement
+
+# Filter by milestone
+gh issue list --milestone "v1.0"
+
+# Search/filter
+gh issue list --search "is:open is:issue label:bug"
+
+# JSON output
+gh issue list --json number,title,state,author
+
+# Table view
+gh issue list --json number,title,labels --jq '.[] | [.number, .title, .labels[].name] | @tsv'
+
+# Show comments count
+gh issue list --json number,title,comments --jq '.[] | [.number, .title, .comments]'
+
+# Sort by
+gh issue list --sort created --order desc
+```
+
+### View Issue
+
+```bash
+# View issue
+gh issue view 123
+
+# View with comments
+gh issue view 123 --comments
+
+# View in browser
+gh issue view 123 --web
+
+# JSON output
+gh issue view 123 --json title,body,state,labels,comments
+
+# View specific fields
+gh issue view 123 --json title --jq '.title'
+```
+
+### Edit Issue
+
+```bash
+# Edit interactively
+gh issue edit 123
+
+# Edit title
+gh issue edit 123 --title "New title"
+
+# Edit body
+gh issue edit 123 --body "New description"
+
+# Add labels
+gh issue edit 123 --add-label bug,high-priority
+
+# Remove labels
+gh issue edit 123 --remove-label stale
+
+# Add assignees
+gh issue edit 123 --add-assignee user1,user2
+
+# Remove assignees
+gh issue edit 123 --remove-assignee user1
+
+# Set milestone
+gh issue edit 123 --milestone "v1.0"
+```
+
+### Close/Reopen Issue
+
+```bash
+# Close issue
+gh issue close 123
+
+# Close with comment
+gh issue close 123 --comment "Fixed in PR #456"
+
+# Reopen issue
+gh issue reopen 123
+```
+
+### Comment on Issue
+
+```bash
+# Add comment
+gh issue comment 123 --body "This looks good!"
+
+# Edit comment
+gh issue comment 123 --edit 456789 --body "Updated comment"
+
+# Delete comment
+gh issue comment 123 --delete 456789
+```
+
+### Issue Status
+
+```bash
+# Show issue status summary
+gh issue status
+
+# Status for specific repository
+gh issue status --repo owner/repo
+```
+
+### Pin/Unpin Issues
+
+```bash
+# Pin issue (pinned to repo dashboard)
+gh issue pin 123
+
+# Unpin issue
+gh issue unpin 123
+```
+
+### Lock/Unlock Issue
+
+```bash
+# Lock conversation
+gh issue lock 123
+
+# Lock with reason
+gh issue lock 123 --reason off-topic
+
+# Unlock
+gh issue unlock 123
+```
+
+### Transfer Issue
+
+```bash
+# Transfer to another repository
+gh issue transfer 123 --repo owner/new-repo
+```
+
+### Delete Issue
+
+```bash
+# Delete issue
+gh issue delete 123
+
+# Confirm without prompt
+gh issue delete 123 --yes
+```
+
+### Develop Issue (Draft PR)
+
+```bash
+# Create draft PR from issue
+gh issue develop 123
+
+# Create in specific branch
+gh issue develop 123 --branch fix/issue-123
+
+# Create with base branch
+gh issue develop 123 --base main
+```
+
+## Pull Requests (gh pr)
+
+### Create Pull Request
+
+```bash
+# Create PR interactively
+gh pr create
+
+# Create with title
+gh pr create --title "Feature: Add new functionality"
+
+# Create with title and body
+gh pr create \
+  --title "Feature: Add new functionality" \
+  --body "This PR adds..."
+
+# Fill body from template
+gh pr create --body-file .github/PULL_REQUEST_TEMPLATE.md
+
+# Set base branch
+gh pr create --base main
+
+# Set head branch (default: current branch)
+gh pr create --head feature-branch
+
+# Create draft PR
+gh pr create --draft
+
+# Add assignees
+gh pr create --assignee user1,user2
+
+# Add reviewers
+gh pr create --reviewer user1,user2
+
+# Add labels
+gh pr create --labels enhancement,feature
+
+# Link to issue
+gh pr create --issue 123
+
+# Create in specific repository
+gh pr create --repo owner/repo
+
+# Open in browser after creation
+gh pr create --web
+```
+
+### List Pull Requests
+
+```bash
+# List open PRs
+gh pr list
+
+# List all PRs
+gh pr list --state all
+
+# List merged PRs
+gh pr list --state merged
+
+# List closed (not merged) PRs
+gh pr list --state closed
+
+# Filter by head branch
+gh pr list --head feature-branch
+
+# Filter by base branch
+gh pr list --base main
+
+# Filter by author
+gh pr list --author username
+gh pr list --author @me
+
+# Filter by assignee
+gh pr list --assignee username
+
+# Filter by labels
+gh pr list --labels bug,enhancement
+
+# Limit results
+gh pr list --limit 50
+
+# Search
+gh pr list --search "is:open is:pr label:review-required"
+
+# JSON output
+gh pr list --json number,title,state,author,headRefName
+
+# Show check status
+gh pr list --json number,title,statusCheckRollup --jq '.[] | [.number, .title, .statusCheckRollup[]?.status]'
+
+# Sort by
+gh pr list --sort created --order desc
+```
+
+### View Pull Request
+
+```bash
+# View PR
+gh pr view 123
+
+# View with comments
+gh pr view 123 --comments
+
+# View in browser
+gh pr view 123 --web
+
+# JSON output
+gh pr view 123 --json title,body,state,author,commits,files
+
+# View diff
+gh pr view 123 --json files --jq '.files[].path'
+
+# View with jq query
+gh pr view 123 --json title,state --jq '"\(.title): \(.state)"'
+```
+
+### Checkout Pull Request
+
+```bash
+# Checkout PR branch
+gh pr checkout 123
+
+# Checkout with specific branch name
+gh pr checkout 123 --branch name-123
+
+# Force checkout
+gh pr checkout 123 --force
+```
+
+### Diff Pull Request
+
+```bash
+# View PR diff
+gh pr diff 123
+
+# View diff with color
+gh pr diff 123 --color always
+
+# Output to file
+gh pr diff 123 > pr-123.patch
+
+# View diff of specific files
+gh pr diff 123 --name-only
+```
+
+### Merge Pull Request
+
+```bash
+# Merge PR
+gh pr merge 123
+
+# Merge with specific method
+gh pr merge 123 --merge
+gh pr merge 123 --squash
+gh pr merge 123 --rebase
+
+# Delete branch after merge
+gh pr merge 123 --delete-branch
+
+# Merge with comment
+gh pr merge 123 --subject "Merge PR #123" --body "Merging feature"
+
+# Merge draft PR
+gh pr merge 123 --admin
+
+# Force merge (skip checks)
+gh pr merge 123 --admin
+```
+
+### Close Pull Request
+
+```bash
+# Close PR (as draft, not merge)
+gh pr close 123
+
+# Close with comment
+gh pr close 123 --comment "Closing due to..."
+```
+
+### Reopen Pull Request
+
+```bash
+# Reopen closed PR
+gh pr reopen 123
+```
+
+### Edit Pull Request
+
+```bash
+# Edit interactively
+gh pr edit 123
+
+# Edit title
+gh pr edit 123 --title "New title"
+
+# Edit body
+gh pr edit 123 --body "New description"
+
+# Add labels
+gh pr edit 123 --add-label bug,enhancement
+
+# Remove labels
+gh pr edit 123 --remove-label stale
+
+# Add assignees
+gh pr edit 123 --add-assignee user1,user2
+
+# Remove assignees
+gh pr edit 123 --remove-assignee user1
+
+# Add reviewers
+gh pr edit 123 --add-reviewer user1,user2
+
+# Remove reviewers
+gh pr edit 123 --remove-reviewer user1
+
+# Mark as ready for review
+gh pr edit 123 --ready
+```
+
+### Ready for Review
+
+```bash
+# Mark draft PR as ready
+gh pr ready 123
+```
+
+### Pull Request Checks
+
+```bash
+# View PR checks
+gh pr checks 123
+
+# Watch checks in real-time
+gh pr checks 123 --watch
+
+# Watch interval (seconds)
+gh pr checks 123 --watch --interval 5
+```
+
+### Comment on Pull Request
+
+```bash
+# Add comment
+gh pr comment 123 --body "Looks good!"
+
+# Comment on specific line
+gh pr comment 123 --body "Fix this" \
+  --repo owner/repo \
+  --head-owner owner --head-branch feature
+
+# Edit comment
+gh pr comment 123 --edit 456789 --body "Updated"
+
+# Delete comment
+gh pr comment 123 --delete 456789
+```
+
+### Review Pull Request
+
+```bash
+# Review PR (opens editor)
+gh pr review 123
+
+# Approve PR
+gh pr review 123 --approve --body "LGTM!"
+
+# Request changes
+gh pr review 123 --request-changes \
+  --body "Please fix these issues"
+
+# Comment on PR
+gh pr review 123 --comment --body "Some thoughts..."
+
+# Dismiss review
+gh pr review 123 --dismiss
+```
+
+### Update Branch
+
+```bash
+# Update PR branch with latest base branch
+gh pr update-branch 123
+
+# Force update
+gh pr update-branch 123 --force
+
+# Use merge strategy
+gh pr update-branch 123 --merge
+```
+
+### Lock/Unlock Pull Request
+
+```bash
+# Lock PR conversation
+gh pr lock 123
+
+# Lock with reason
+gh pr lock 123 --reason off-topic
+
+# Unlock
+gh pr unlock 123
+```
+
+### Revert Pull Request
+
+```bash
+# Revert merged PR
+gh pr revert 123
+
+# Revert with specific branch name
+gh pr revert 123 --branch revert-pr-123
+```
+
+### Pull Request Status
+
+```bash
+# Show PR status summary
+gh pr status
+
+# Status for specific repository
+gh pr status --repo owner/repo
+```
+
+## GitHub Actions
+
+### Workflow Runs (gh run)
+
+```bash
+# List workflow runs
+gh run list
+
+# List for specific workflow
+gh run list --workflow "ci.yml"
+
+# List for specific branch
+gh run list --branch main
+
+# Limit results
+gh run list --limit 20
+
+# JSON output
+gh run list --json databaseId,status,conclusion,headBranch
+
+# View run details
+gh run view 123456789
+
+# View run with verbose logs
+gh run view 123456789 --log
+
+# View specific job
+gh run view 123456789 --job 987654321
+
+# View in browser
+gh run view 123456789 --web
+
+# Watch run in real-time
+gh run watch 123456789
+
+# Watch with interval
+gh run watch 123456789 --interval 5
+
+# Rerun failed run
+gh run rerun 123456789
+
+# Rerun specific job
+gh run rerun 123456789 --job 987654321
+
+# Cancel run
+gh run cancel 123456789
+
+# Delete run
+gh run delete 123456789
+
+# Download run artifacts
+gh run download 123456789
+
+# Download specific artifact
+gh run download 123456789 --name build
+
+# Download to directory
+gh run download 123456789 --dir ./artifacts
+```
+
+### Workflows (gh workflow)
+
+```bash
+# List workflows
+gh workflow list
+
+# View workflow details
+gh workflow view ci.yml
+
+# View workflow YAML
+gh workflow view ci.yml --yaml
+
+# View in browser
+gh workflow view ci.yml --web
+
+# Enable workflow
+gh workflow enable ci.yml
+
+# Disable workflow
+gh workflow disable ci.yml
+
+# Run workflow manually
+gh workflow run ci.yml
+
+# Run with inputs
+gh workflow run ci.yml \
+  --raw-field \
+  version="1.0.0" \
+  environment="production"
+
+# Run from specific branch
+gh workflow run ci.yml --ref develop
+```
+
+### Action Caches (gh cache)
+
+```bash
+# List caches
+gh cache list
+
+# List for specific branch
+gh cache list --branch main
+
+# List with limit
+gh cache list --limit 50
+
+# Delete cache
+gh cache delete 123456789
+
+# Delete all caches
+gh cache delete --all
+```
+
+### Action Secrets (gh secret)
+
+```bash
+# List secrets
+gh secret list
+
+# Set secret (prompts for value)
+gh secret set MY_SECRET
+
+# Set secret from environment
+echo "$MY_SECRET" | gh secret set MY_SECRET
+
+# Set secret for specific environment
+gh secret set MY_SECRET --env production
+
+# Set secret for organization
+gh secret set MY_SECRET --org orgname
+
+# Delete secret
+gh secret delete MY_SECRET
+
+# Delete from environment
+gh secret delete MY_SECRET --env production
+```
+
+### Action Variables (gh variable)
+
+```bash
+# List variables
+gh variable list
+
+# Set variable
+gh variable set MY_VAR "some-value"
+
+# Set variable for environment
+gh variable set MY_VAR "value" --env production
+
+# Set variable for organization
+gh variable set MY_VAR "value" --org orgname
+
+# Get variable value
+gh variable get MY_VAR
+
+# Delete variable
+gh variable delete MY_VAR
+
+# Delete from environment
+gh variable delete MY_VAR --env production
+```
+
+## Projects (gh project)
+
+```bash
+# List projects
+gh project list
+
+# List for owner
+gh project list --owner owner
+
+# Open projects
+gh project list --open
+
+# View project
+gh project view 123
+
+# View project items
+gh project view 123 --format json
+
+# Create project
+gh project create --title "My Project"
+
+# Create in organization
+gh project create --title "Project" --org orgname
+
+# Create with readme
+gh project create --title "Project" --readme "Description here"
+
+# Edit project
+gh project edit 123 --title "New Title"
+
+# Delete project
+gh project delete 123
+
+# Close project
+gh project close 123
+
+# Copy project
+gh project copy 123 --owner target-owner --title "Copy"
+
+# Mark template
+gh project mark-template 123
+
+# List fields
+gh project field-list 123
+
+# Create field
+gh project field-create 123 --title "Status" --datatype single_select
+
+# Delete field
+gh project field-delete 123 --id 456
+
+# List items
+gh project item-list 123
+
+# Create item
+gh project item-create 123 --title "New item"
+
+# Add item to project
+gh project item-add 123 --owner-owner --repo repo --issue 456
+
+# Edit item
+gh project item-edit 123 --id 456 --title "Updated title"
+
+# Delete item
+gh project item-delete 123 --id 456
+
+# Archive item
+gh project item-archive 123 --id 456
+
+# Link items
+gh project link 123 --id 456 --link-id 789
+
+# Unlink items
+gh project unlink 123 --id 456 --link-id 789
+
+# View project in browser
+gh project view 123 --web
+```
+
+## Releases (gh release)
+
+```bash
+# List releases
+gh release list
+
+# View latest release
+gh release view
+
+# View specific release
+gh release view v1.0.0
+
+# View in browser
+gh release view v1.0.0 --web
+
+# Create release
+gh release create v1.0.0 \
+  --notes "Release notes here"
+
+# Create release with notes from file
+gh release create v1.0.0 --notes-file notes.md
+
+# Create release with target
+gh release create v1.0.0 --target main
+
+# Create release as draft
+gh release create v1.0.0 --draft
+
+# Create pre-release
+gh release create v1.0.0 --prerelease
+
+# Create release with title
+gh release create v1.0.0 --title "Version 1.0.0"
+
+# Upload asset to release
+gh release upload v1.0.0 ./file.tar.gz
+
+# Upload multiple assets
+gh release upload v1.0.0 ./file1.tar.gz ./file2.tar.gz
+
+# Upload with label (casing sensitive)
+gh release upload v1.0.0 ./file.tar.gz --casing
+
+# Delete release
+gh release delete v1.0.0
+
+# Delete with cleanup tag
+gh release delete v1.0.0 --yes
+
+# Delete specific asset
+gh release delete-asset v1.0.0 file.tar.gz
+
+# Download release assets
+gh release download v1.0.0
+
+# Download specific asset
+gh release download v1.0.0 --pattern "*.tar.gz"
+
+# Download to directory
+gh release download v1.0.0 --dir ./downloads
+
+# Download archive (zip/tar)
+gh release download v1.0.0 --archive zip
+
+# Edit release
+gh release edit v1.0.0 --notes "Updated notes"
+
+# Verify release signature
+gh release verify v1.0.0
+
+# Verify specific asset
+gh release verify-asset v1.0.0 file.tar.gz
+```
+
+## Gists (gh gist)
+
+```bash
+# List gists
+gh gist list
+
+# List all gists (including private)
+gh gist list --public
+
+# Limit results
+gh gist list --limit 20
+
+# View gist
+gh gist view abc123
+
+# View gist files
+gh gist view abc123 --files
+
+# Create gist
+gh gist create script.py
+
+# Create gist with description
+gh gist create script.py --desc "My script"
+
+# Create public gist
+gh gist create script.py --public
+
+# Create multi-file gist
+gh gist create file1.py file2.py
+
+# Create from stdin
+echo "print('hello')" | gh gist create
+
+# Edit gist
+gh gist edit abc123
+
+# Delete gist
+gh gist delete abc123
+
+# Rename gist file
+gh gist rename abc123 --filename old.py new.py
+
+# Clone gist
+gh gist clone abc123
+
+# Clone to directory
+gh gist clone abc123 my-directory
+```
+
+## Codespaces (gh codespace)
+
+```bash
+# List codespaces
+gh codespace list
+
+# Create codespace
+gh codespace create
+
+# Create with specific repository
+gh codespace create --repo owner/repo
+
+# Create with branch
+gh codespace create --branch develop
+
+# Create with specific machine
+gh codespace create --machine premiumLinux
+
+# View codespace details
+gh codespace view
+
+# SSH into codespace
+gh codespace ssh
+
+# SSH with specific command
+gh codespace ssh --command "cd /workspaces && ls"
+
+# Open codespace in browser
+gh codespace code
+
+# Open in VS Code
+gh codespace code --codec
+
+# Open with specific path
+gh codespace code --path /workspaces/repo
+
+# Stop codespace
+gh codespace stop
+
+# Delete codespace
+gh codespace delete
+
+# View logs
+gh codespace logs
+
+--tail 100
+
+# View ports
+gh codespace ports
+
+# Forward port
+gh codespace cp 8080:8080
+
+# Rebuild codespace
+gh codespace rebuild
+
+# Edit codespace
+gh codespace edit --machine standardLinux
+
+# Jupyter support
+gh codespace jupyter
+
+# Copy files to/from codespace
+gh codespace cp file.txt :/workspaces/file.txt
+gh codespace cp :/workspaces/file.txt ./file.txt
+```
+
+## Organizations (gh org)
+
+```bash
+# List organizations
+gh org list
+
+# List for user
+gh org list --user username
+
+# JSON output
+gh org list --json login,name,description
+
+# View organization
+gh org view orgname
+
+# View organization members
+gh org view orgname --json members --jq '.members[] | .login'
+```
+
+## Search (gh search)
+
+```bash
+# Search code
+gh search code "TODO"
+
+# Search in specific repository
+gh search code "TODO" --repo owner/repo
+
+# Search commits
+gh search commits "fix bug"
+
+# Search issues
+gh search issues "label:bug state:open"
+
+# Search PRs
+gh search prs "is:open is:pr review:required"
+
+# Search repositories
+gh search repos "stars:>1000 language:python"
+
+# Limit results
+gh search repos "topic:api" --limit 50
+
+# JSON output
+gh search repos "stars:>100" --json name,description,stargazers
+
+# Order results
+gh search repos "language:rust" --order desc --sort stars
+
+# Search with extensions
+gh search code "import" --extension py
+
+# Web search (open in browser)
+gh search prs "is:open" --web
+```
+
+## Labels (gh label)
+
+```bash
+# List labels
+gh label list
+
+# Create label
+gh label create bug --color "d73a4a" --description "Something isn't working"
+
+# Create with hex color
+gh label create enhancement --color "#a2eeef"
+
+# Edit label
+gh label edit bug --name "bug-report" --color "ff0000"
+
+# Delete label
+gh label delete bug
+
+# Clone labels from repository
+gh label clone owner/repo
+
+# Clone to specific repository
+gh label clone owner/repo --repo target/repo
+```
+
+## SSH Keys (gh ssh-key)
+
+```bash
+# List SSH keys
+gh ssh-key list
+
+# Add SSH key
+gh ssh-key add ~/.ssh/id_rsa.pub --title "My laptop"
+
+# Add key with type
+gh ssh-key add ~/.ssh/id_ed25519.pub --type "authentication"
+
+# Delete SSH key
+gh ssh-key delete 12345
+
+# Delete by title
+gh ssh-key delete --title "My laptop"
+```
+
+## GPG Keys (gh gpg-key)
+
+```bash
+# List GPG keys
+gh gpg-key list
+
+# Add GPG key
+gh gpg-key add ~/.ssh/id_rsa.pub
+
+# Delete GPG key
+gh gpg-key delete 12345
+
+# Delete by key ID
+gh gpg-key delete ABCD1234
+```
+
+## Status (gh status)
+
+```bash
+# Show status overview
+gh status
+
+# Status for specific repositories
+gh status --repo owner/repo
+
+# JSON output
+gh status --json
+```
+
+## Configuration (gh config)
+
+```bash
+# List all config
+gh config list
+
+# Get specific value
+gh config get editor
+
+# Set value
+gh config set editor vim
+
+# Set git protocol
+gh config set git_protocol ssh
+
+# Clear cache
+gh config clear-cache
+
+# Set prompt behavior
+gh config set prompt disabled
+gh config set prompt enabled
+```
+
+## Extensions (gh extension)
+
+```bash
+# List installed extensions
+gh extension list
+
+# Search extensions
+gh extension search github
+
+# Install extension
+gh extension install owner/extension-repo
+
+# Install from branch
+gh extension install owner/extension-repo --branch develop
+
+# Upgrade extension
+gh extension upgrade extension-name
+
+# Remove extension
+gh extension remove extension-name
+
+# Create new extension
+gh extension create my-extension
+
+# Browse extensions
+gh extension browse
+
+# Execute extension command
+gh extension exec my-extension --arg value
+```
+
+## Aliases (gh alias)
+
+```bash
+# List aliases
+gh alias list
+
+# Set alias
+gh alias set prview 'pr view --web'
+
+# Set shell alias
+gh alias set co 'pr checkout' --shell
+
+# Delete alias
+gh alias delete prview
+
+# Import aliases
+gh alias import ./aliases.sh
+```
+
+## API Requests (gh api)
+
+```bash
+# Make API request
+gh api /user
+
+# Request with method
+gh api --method POST /repos/owner/repo/issues \
+  --field title="Issue title" \
+  --field body="Issue body"
+
+# Request with headers
+gh api /user \
+  --header "Accept: application/vnd.github.v3+json"
+
+# Request with pagination
+gh api /user/repos --paginate
+
+# Raw output (no formatting)
+gh api /user --raw
+
+# Include headers in output
+gh api /user --include
+
+# Silent mode (no progress output)
+gh api /user --silent
+
+# Input from file
+gh api --input request.json
+
+# jq query on response
+gh api /user --jq '.login'
+
+# Field from response
+gh api /repos/owner/repo --jq '.stargazers_count'
+
+# GitHub Enterprise
+gh api /user --hostname enterprise.internal
+
+# GraphQL query
+gh api graphql \
+  -f query='
+  {
+    viewer {
+      login
+      repositories(first: 5) {
+        nodes {
+          name
+        }
+      }
+    }
+  }'
+```
+
+## Rulesets (gh ruleset)
+
+```bash
+# List rulesets
+gh ruleset list
+
+# View ruleset
+gh ruleset view 123
+
+# Check ruleset
+gh ruleset check --branch feature
+
+# Check specific repository
+gh ruleset check --repo owner/repo --branch main
+```
+
+## Attestations (gh attestation)
+
+```bash
+# Download attestation
+gh attestation download owner/repo \
+  --artifact-id 123456
+
+# Verify attestation
+gh attestation verify owner/repo
+
+# Get trusted root
+gh attestation trusted-root
+```
+
+## Completion (gh completion)
+
+```bash
+# Generate shell completion
+gh completion -s bash > ~/.gh-complete.bash
+gh completion -s zsh > ~/.gh-complete.zsh
+gh completion -s fish > ~/.gh-complete.fish
+gh completion -s powershell > ~/.gh-complete.ps1
+
+# Shell-specific instructions
+gh completion --shell=bash
+gh completion --shell=zsh
+```
+
+## Preview (gh preview)
+
+```bash
+# List preview features
+gh preview
+
+# Run preview script
+gh preview prompter
+```
+
+## Agent Tasks (gh agent-task)
+
+```bash
+# List agent tasks
+gh agent-task list
+
+# View agent task
+gh agent-task view 123
+
+# Create agent task
+gh agent-task create --description "My task"
+```
+
+## Global Flags
+
+| Flag                       | Description                            |
+| -------------------------- | -------------------------------------- |
+| `--help` / `-h`            | Show help for command                  |
+| `--version`                | Show gh version                        |
+| `--repo [HOST/]OWNER/REPO` | Select another repository              |
+| `--hostname HOST`          | GitHub hostname                        |
+| `--jq EXPRESSION`          | Filter JSON output                     |
+| `--json FIELDS`            | Output JSON with specified fields      |
+| `--template STRING`        | Format JSON using Go template          |
+| `--web`                    | Open in browser                        |
+| `--paginate`               | Make additional API calls              |
+| `--verbose`                | Show verbose output                    |
+| `--debug`                  | Show debug output                      |
+| `--timeout SECONDS`        | Maximum API request duration           |
+| `--cache CACHE`            | Cache control (default, force, bypass) |
+
+## Output Formatting
+
+### JSON Output
+
+```bash
+# Basic JSON
+gh repo view --json name,description
+
+# Nested fields
+gh repo view --json owner,name --jq '.owner.login + "/" + .name'
+
+# Array operations
+gh pr list --json number,title --jq '.[] | select(.number > 100)'
+
+# Complex queries
+gh issue list --json number,title,labels \
+  --jq '.[] | {number, title: .title, tags: [.labels[].name]}'
+```
+
+### Template Output
+
+```bash
+# Custom template
+gh repo view \
+  --template '{{.name}}: {{.description}}'
+
+# Multiline template
+gh pr view 123 \
+  --template 'Title: {{.title}}
+Author: {{.author.login}}
+State: {{.state}}
+'
+```
+
+## Common Workflows
+
+### Create PR from Issue
+
+```bash
+# Create branch from issue
+gh issue develop 123 --branch feature/issue-123
+
+# Make changes, commit, push
+git add .
+git commit -m "Fix issue #123"
+git push
+
+# Create PR linking to issue
+gh pr create --title "Fix #123" --body "Closes #123"
+```
+
+### Bulk Operations
+
+```bash
+# Close multiple issues
+gh issue list --search "label:stale" \
+  --json number \
+  --jq '.[].number' | \
+  xargs -I {} gh issue close {} --comment "Closing as stale"
+
+# Add label to multiple PRs
+gh pr list --search "review:required" \
+  --json number \
+  --jq '.[].number' | \
+  xargs -I {} gh pr edit {} --add-label needs-review
+```
+
+### Repository Setup Workflow
+
+```bash
+# Create repository with initial setup
+gh repo create my-project --public \
+  --description "My awesome project" \
+  --clone \
+  --gitignore python \
+  --license mit
+
+cd my-project
+
+# Set up branches
+git checkout -b develop
+git push -u origin develop
+
+# Create labels
+gh label create bug --color "d73a4a" --description "Bug report"
+gh label create enhancement --color "a2eeef" --description "Feature request"
+gh label create documentation --color "0075ca" --description "Documentation"
+```
+
+### CI/CD Workflow
+
+```bash
+# Run workflow and wait
+RUN_ID=$(gh workflow run ci.yml --ref main --jq '.databaseId')
+
+# Watch the run
+gh run watch "$RUN_ID"
+
+# Download artifacts on completion
+gh run download "$RUN_ID" --dir ./artifacts
+```
+
+### Fork Sync Workflow
+
+```bash
+# Fork repository
+gh repo fork original/repo --clone
+
+cd repo
+
+# Add upstream remote
+git remote add upstream https://github.com/original/repo.git
+
+# Sync fork
+gh repo sync
+
+# Or manual sync
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
+
+## Environment Setup
+
+### Shell Integration
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+eval "$(gh completion -s bash)"  # or zsh/fish
+
+# Create useful aliases
+alias gs='gh status'
+alias gpr='gh pr view --web'
+alias gir='gh issue view --web'
+alias gco='gh pr checkout'
+```
+
+### Git Configuration
+
+```bash
+# Use gh as credential helper
+gh auth setup-git
+
+# Set gh as default for repo operations
+git config --global credential.helper 'gh !gh auth setup-git'
+
+# Or manually
+git config --global credential.helper github
+```
+
+## Best Practices
+
+1. **Authentication**: Use environment variables for automation
+
+   ```bash
+   export GH_TOKEN=$(gh auth token)
+   ```
+
+2. **Default Repository**: Set default to avoid repetition
+
+   ```bash
+   gh repo set-default owner/repo
+   ```
+
+3. **JSON Parsing**: Use jq for complex data extraction
+
+   ```bash
+   gh pr list --json number,title --jq '.[] | select(.title | contains("fix"))'
+   ```
+
+4. **Pagination**: Use --paginate for large result sets
+
+   ```bash
+   gh issue list --state all --paginate
+   ```
+
+5. **Caching**: Use cache control for frequently accessed data
+   ```bash
+   gh api /user --cache force
+   ```
+
+## Getting Help
+
+```bash
+# General help
+gh --help
+
+# Command help
+gh pr --help
+gh issue create --help
+
+# Help topics
+gh help formatting
+gh help environment
+gh help exit-codes
+gh help accessibility
+```
+
+## References
+
+- Official Manual: https://cli.github.com/manual/
+- GitHub Docs: https://docs.github.com/en/github-cli
+- REST API: https://docs.github.com/en/rest
+- GraphQL API: https://docs.github.com/en/graphql

--- a/.agents/skills/modern-python/SKILL.md
+++ b/.agents/skills/modern-python/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: modern-python
+description: Configures Python projects with modern tooling (uv, ruff, ty). Use when creating projects, writing standalone scripts, or migrating from pip/Poetry/mypy/black.
+---
+
+# Modern Python
+
+Guide for modern Python tooling and best practices, based on [trailofbits/cookiecutter-python](https://github.com/trailofbits/cookiecutter-python).
+
+## When to Use This Skill
+
+- Creating a new Python project or package
+- Setting up `pyproject.toml` configuration
+- Configuring development tools (linting, formatting, testing)
+- Writing Python scripts with external dependencies
+- Migrating from legacy tools (when user requests it)
+
+## When NOT to Use This Skill
+
+- **User wants to keep legacy tooling**: Respect existing workflows if explicitly requested
+- **Python < 3.11 required**: These tools target modern Python
+- **Non-Python projects**: Mixed codebases where Python isn't primary
+
+## Anti-Patterns to Avoid
+
+| Avoid | Use Instead |
+|-------|-------------|
+| `[tool.ty]` python-version | `[tool.ty.environment]` python-version |
+| `uv pip install` | `uv add` and `uv sync` |
+| Editing pyproject.toml manually to add deps | `uv add <pkg>` / `uv remove <pkg>` |
+| `hatchling` build backend | `uv_build` (simpler, sufficient for most cases) |
+| Poetry | uv (faster, simpler, better ecosystem integration) |
+| requirements.txt | PEP 723 for scripts, pyproject.toml for projects |
+| mypy / pyright | ty (faster, from Astral team) |
+| `[project.optional-dependencies]` for dev tools | `[dependency-groups]` (PEP 735) |
+| Manual virtualenv activation (`source .venv/bin/activate`) | `uv run <cmd>` |
+| pre-commit | prek (faster, no Python runtime needed) |
+
+**Key principles:**
+- Always use `uv add` and `uv remove` to manage dependencies
+- Never manually activate or manage virtual environments—use `uv run` for all commands
+- Use `[dependency-groups]` for dev/test/docs dependencies, not `[project.optional-dependencies]`
+
+## Decision Tree
+
+```
+What are you doing?
+│
+├─ Single-file script with dependencies?
+│   └─ Use PEP 723 inline metadata (./references/pep723-scripts.md)
+│
+├─ New multi-file project (not distributed)?
+│   └─ Minimal uv setup (see Quick Start below)
+│
+├─ New reusable package/library?
+│   └─ Full project setup (see Full Setup below)
+│
+└─ Migrating existing project?
+    └─ See Migration Guide below
+```
+
+## Tool Overview
+
+| Tool | Purpose | Replaces |
+|------|---------|----------|
+| **uv** | Package/dependency management | pip, virtualenv, pip-tools, pipx, pyenv |
+| **ruff** | Linting AND formatting | flake8, black, isort, pyupgrade, pydocstyle |
+| **ty** | Type checking | mypy, pyright (faster alternative) |
+| **pytest** | Testing with coverage | unittest |
+| **prek** | Pre-commit hooks ([setup](./references/prek.md)) | pre-commit (faster, Rust-native) |
+
+### Security Tools
+
+| Tool | Purpose | When It Runs |
+|------|---------|--------------|
+| **shellcheck** | Shell script linting | pre-commit |
+| **detect-secrets** | Secret detection | pre-commit |
+| **actionlint** | Workflow syntax validation | pre-commit, CI |
+| **zizmor** | Workflow security audit | pre-commit, CI |
+| **pip-audit** | Dependency vulnerability scanning | CI, manual |
+| **Dependabot** | Automated dependency updates | scheduled |
+
+See [security-setup.md](./references/security-setup.md) for configuration and usage.
+
+## Quick Start: Minimal Project
+
+For simple multi-file projects not intended for distribution:
+
+```bash
+# Create project with uv
+uv init myproject
+cd myproject
+
+# Add dependencies
+uv add requests rich
+
+# Add dev dependencies
+uv add --group dev pytest ruff ty
+
+# Run code
+uv run python src/myproject/main.py
+
+# Run tools
+uv run pytest
+uv run ruff check .
+```
+
+## Full Project Setup
+If starting from scratch, ask the user if they prefer to use the Trail of Bits cookiecutter template to bootstrap a complete project with already preconfigured tooling.
+
+```bash
+uvx cookiecutter gh:trailofbits/cookiecutter-python
+```
+
+### 1. Create Project Structure
+
+```bash
+uv init --package myproject
+cd myproject
+```
+
+This creates:
+```
+myproject/
+├── pyproject.toml
+├── README.md
+├── src/
+│   └── myproject/
+│       └── __init__.py
+└── .python-version
+```
+
+### 2. Configure pyproject.toml
+
+See [pyproject.md](./references/pyproject.md) for complete configuration reference.
+
+Key sections:
+```toml
+[project]
+name = "myproject"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = []
+
+[dependency-groups]
+dev = [{include-group = "lint"}, {include-group = "test"}, {include-group = "audit"}]
+lint = ["ruff", "ty"]
+test = ["pytest", "pytest-cov"]
+audit = ["pip-audit"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = ["D", "COM812", "ISC001"]
+
+[tool.pytest]
+addopts = ["--cov=myproject", "--cov-fail-under=80"]
+
+[tool.ty.terminal]
+error-on-warning = true
+
+[tool.ty.environment]
+python-version = "3.11"
+
+[tool.ty.rules]
+# Strict from day 1 for new projects
+possibly-unresolved-reference = "error"
+unused-ignore-comment = "warn"
+```
+
+### 3. Install Dependencies
+
+```bash
+# Install all dependency groups
+uv sync --all-groups
+
+# Or install specific groups
+uv sync --group dev
+```
+
+### 4. Add Makefile
+
+```makefile
+.PHONY: dev lint format test build
+
+dev:
+	uv sync --all-groups
+
+lint:
+	uv run ruff format --check && uv run ruff check && uv run ty check src/
+
+format:
+	uv run ruff format .
+
+test:
+	uv run pytest
+
+build:
+	uv build
+```
+
+## Migration Guide
+
+When a user requests migration from legacy tooling:
+
+### From requirements.txt + pip
+
+First, determine the nature of the code:
+
+**For standalone scripts**: Convert to PEP 723 inline metadata (see [pep723-scripts.md](./references/pep723-scripts.md))
+
+**For projects**:
+```bash
+# Initialize uv in existing project
+uv init --bare
+
+# Add dependencies using uv (not by editing pyproject.toml)
+uv add requests rich  # add each package
+
+# Or import from requirements.txt (review each package before adding)
+# Note: Complex version specifiers may need manual handling
+grep -v '^#' requirements.txt | grep -v '^-' | grep -v '^\s*$' | while read -r pkg; do
+    uv add "$pkg" || echo "Failed to add: $pkg"
+done
+
+uv sync
+```
+
+Then:
+1. Delete `requirements.txt`, `requirements-dev.txt`
+2. Delete virtual environment (`venv/`, `.venv/`)
+3. Add `uv.lock` to version control
+
+### From setup.py / setup.cfg
+
+1. Run `uv init --bare` to create pyproject.toml
+2. Use `uv add` to add each dependency from `install_requires`
+3. Use `uv add --group dev` for dev dependencies
+4. Copy non-dependency metadata (name, version, description, etc.) to `[project]`
+5. Delete `setup.py`, `setup.cfg`, `MANIFEST.in`
+
+### From flake8 + black + isort
+
+1. Remove flake8, black, isort via `uv remove`
+2. Delete `.flake8`, `pyproject.toml [tool.black]`, `[tool.isort]` configs
+3. Add ruff: `uv add --group dev ruff`
+4. Add ruff configuration (see [ruff-config.md](./references/ruff-config.md))
+5. Run `uv run ruff check --fix .` to apply fixes
+6. Run `uv run ruff format .` to format
+
+### From mypy / pyright
+
+1. Remove mypy/pyright via `uv remove`
+2. Delete `mypy.ini`, `pyrightconfig.json`, or `[tool.mypy]`/`[tool.pyright]` sections
+3. Add ty: `uv add --group dev ty`
+4. Run `uv run ty check src/`
+
+## Quick Reference: uv Commands
+
+| Command | Description |
+|---------|-------------|
+| `uv init` | Create new project |
+| `uv init --package` | Create distributable package |
+| `uv add <pkg>` | Add dependency |
+| `uv add --group dev <pkg>` | Add to dependency group |
+| `uv remove <pkg>` | Remove dependency |
+| `uv sync` | Install dependencies |
+| `uv sync --all-groups` | Install all dependency groups |
+| `uv run <cmd>` | Run command in venv |
+| `uv run --with <pkg> <cmd>` | Run with temporary dependency |
+| `uv build` | Build package |
+| `uv publish` | Publish to PyPI |
+
+### Ad-hoc Dependencies with `--with`
+
+Use `uv run --with` for one-off commands that need packages not in your project:
+
+```bash
+# Run Python with a temporary package
+uv run --with requests python -c "import requests; print(requests.get('https://httpbin.org/ip').json())"
+
+# Run a module with temporary deps
+uv run --with rich python -m rich.progress
+
+# Multiple packages
+uv run --with requests --with rich python script.py
+
+# Combine with project deps (adds to existing venv)
+uv run --with httpx pytest  # project deps + httpx
+```
+
+**When to use `--with` vs `uv add`:**
+- `uv add`: Package is a project dependency (goes in pyproject.toml/uv.lock)
+- `--with`: One-off usage, testing, or scripts outside a project context
+
+See [uv-commands.md](./references/uv-commands.md) for complete reference.
+
+## Quick Reference: Dependency Groups
+
+```toml
+[dependency-groups]
+dev = ["ruff", "ty"]
+test = ["pytest", "pytest-cov", "hypothesis"]
+docs = ["sphinx", "myst-parser"]
+```
+
+Install with: `uv sync --group dev --group test`
+
+## Best Practices Checklist
+
+- [ ] Use `src/` layout for packages
+- [ ] Set `requires-python = ">=3.11"`
+- [ ] Configure ruff with `select = ["ALL"]` and explicit ignores
+- [ ] Use ty for type checking
+- [ ] Enforce test coverage minimum (80%+)
+- [ ] Use dependency groups instead of extras for dev tools
+- [ ] Add `uv.lock` to version control
+- [ ] Use PEP 723 for standalone scripts
+
+## Read Next
+
+- [migration-checklist.md](./references/migration-checklist.md) - Step-by-step migration cleanup
+- [pyproject.md](./references/pyproject.md) - Complete pyproject.toml reference
+- [uv-commands.md](./references/uv-commands.md) - uv command reference
+- [ruff-config.md](./references/ruff-config.md) - Ruff linting/formatting configuration
+- [testing.md](./references/testing.md) - pytest and coverage setup
+- [pep723-scripts.md](./references/pep723-scripts.md) - PEP 723 inline script metadata
+- [prek.md](./references/prek.md) - Fast pre-commit hooks with prek
+- [security-setup.md](./references/security-setup.md) - Security hooks and dependency scanning
+- [dependabot.md](./references/dependabot.md) - Automated dependency updates

--- a/.agents/skills/modern-python/references/dependabot.md
+++ b/.agents/skills/modern-python/references/dependabot.md
@@ -1,0 +1,43 @@
+# Dependabot: Automated Dependency Updates
+
+[Dependabot](https://docs.github.com/en/code-security/dependabot) automatically creates pull requests to keep your dependencies up to date. GitHub hosts it natively—no external service required.
+
+## Why Use Dependabot?
+
+- **Security**: Automatically patches known vulnerabilities
+- **Freshness**: Keeps dependencies current without manual tracking
+- **Visibility**: PRs show changelogs and compatibility notes
+
+## Configuration
+
+Copy [templates/dependabot.yml](../templates/dependabot.yml) to `.github/dependabot.yml`.
+
+The template includes:
+- Weekly update schedule for pip and GitHub Actions
+- 7-day cooldown for supply chain protection
+- Grouping to reduce PR noise
+
+## Supply Chain Protection
+
+The `cooldown.default-days: 7` setting delays updates for newly published versions. This provides time for the community to detect compromised packages before they reach your project.
+
+**Why this matters:**
+- Attackers sometimes publish malicious versions of legitimate packages
+- A 7-day delay allows time for detection and removal
+- Combined with weekly schedules, this balances security with freshness
+
+## Common Options
+
+| Option | Description |
+|--------|-------------|
+| `interval` | `daily`, `weekly`, or `monthly` |
+| `cooldown.default-days` | Days to wait before updating new releases |
+| `ignore` | Skip specific dependencies or versions |
+| `groups` | Group related updates into single PRs |
+| `reviewers` | Auto-assign reviewers to PRs |
+
+## See Also
+
+- [GitHub Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
+- [security-setup.md](./security-setup.md) - Security tooling overview
+- [prek.md](./prek.md) - Pre-commit hooks (complementary tool)

--- a/.agents/skills/modern-python/references/migration-checklist.md
+++ b/.agents/skills/modern-python/references/migration-checklist.md
@@ -1,0 +1,141 @@
+# Migration Checklist
+
+Comprehensive checklist for migrating Python projects to modern tooling.
+
+## Before Migration
+
+- [ ] **Determine layout**: `src/` or flat? Configure `[tool.uv.build-backend]` if flat
+- [ ] **Decide uv.lock strategy**: app (commit) vs library (.gitignore)
+- [ ] **Backup current state**: Create a branch or tag before starting
+
+## Cleanup Old Artifacts
+
+Find and remove legacy linter comments:
+
+```bash
+# Find files with old linter pragmas
+rg "# pylint:|# noqa:|# type: ignore" --files-with-matches
+
+# Find missing __init__.py files
+uv run ruff check --select=INP001 .
+```
+
+Remove these files after migration:
+- [ ] `requirements.txt`, `requirements-dev.txt`
+- [ ] `setup.py`, `setup.cfg`, `MANIFEST.in`
+- [ ] `.flake8`, `mypy.ini`, `pyrightconfig.json`
+- [ ] `tox.ini` (if not needed)
+- [ ] `Pipfile`, `Pipfile.lock`
+- [ ] Old virtual environments (`venv/`, `.venv/`)
+
+## .gitignore Updates
+
+Add these entries:
+
+```gitignore
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+
+# Tools
+.ruff_cache/
+.ty/
+
+# uv (for libraries only - apps should commit uv.lock)
+# uv.lock
+```
+
+## pyproject.toml Sections to Remove
+
+- [ ] `[tool.black]`
+- [ ] `[tool.isort]`
+- [ ] `[tool.mypy]`
+- [ ] `[tool.pyright]`
+- [ ] `[tool.pylint]`
+- [ ] `[tool.flake8]` (if present)
+
+## Post-Migration Easy Wins
+
+Run these to modernize code automatically:
+
+```bash
+# Pyupgrade modernization (typing, syntax)
+uv run ruff check --select=UP --fix .
+
+# Unnecessary variable assignments before return
+uv run ruff check --select=RET504 --fix .
+
+# Simplifications (conditionals, comprehensions)
+uv run ruff check --select=SIM --fix .
+
+# Remove commented-out code
+uv run ruff check --select=ERA --fix .
+```
+
+## CI Cleanup
+
+- [ ] Remove scheduled CI triggers (activity without progress is theater)
+- [ ] Update CI to use `uv sync` and `uv run`
+- [ ] Pin GitHub Actions to SHA hashes
+- [ ] Set up security tooling (see [security-setup.md](./security-setup.md))
+
+## Gradual ty Adoption
+
+For legacy codebases with many type errors, start lenient:
+
+```toml
+[tool.ty.terminal]
+error-on-warning = true
+
+[tool.ty.environment]
+python-version = "3.11"
+
+[tool.ty.rules]
+# Start with these ignored for legacy codebases
+possibly-missing-attribute = "ignore"
+unresolved-import = "ignore"
+invalid-argument-type = "ignore"
+not-subscriptable = "ignore"
+unresolved-attribute = "ignore"
+```
+
+Remove rules as you fix errors. Track progress:
+
+```bash
+# Count remaining issues
+uv run ty check src/ 2>&1 | grep -c "error"
+```
+
+## Supply Chain Security
+
+- [ ] Add pip-audit to dependency groups
+- [ ] Configure Dependabot with 7-day cooldown
+- [ ] Pin exact versions in production (`==` not `>=`)
+
+See [security-setup.md](./security-setup.md) for pip-audit and Dependabot configuration.
+
+## Verification
+
+After migration, verify everything works:
+
+```bash
+# Install all dependencies
+uv sync --all-groups
+
+# Run linting
+uv run ruff check .
+uv run ruff format --check .
+
+# Run type checking
+uv run ty check src/
+
+# Run tests
+uv run pytest
+
+# Security audit
+uv run pip-audit
+
+# Build package (if distributable)
+uv build
+```

--- a/.agents/skills/modern-python/references/pep723-scripts.md
+++ b/.agents/skills/modern-python/references/pep723-scripts.md
@@ -1,0 +1,259 @@
+# PEP 723: Inline Script Metadata
+
+PEP 723 allows embedding dependency metadata directly in Python scripts, eliminating the need for separate `requirements.txt` or `pyproject.toml` files for simple scripts.
+
+## When to Use PEP 723
+
+**Use for:**
+- Single-file scripts with external dependencies
+- Quick automation scripts
+- Utility scripts shared between projects
+- Scripts that need to be self-contained
+
+**Don't use for:**
+- Multi-file projects (use `pyproject.toml`)
+- Reusable packages/libraries
+- Projects requiring complex configuration
+
+## Basic Syntax
+
+The metadata block uses TOML format embedded in a special comment:
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "requests",
+#     "rich",
+# ]
+# ///
+
+import requests
+from rich import print
+
+response = requests.get("https://api.example.com/data")
+print(response.json())
+```
+
+## Running Scripts
+
+```bash
+# With uv (recommended)
+uv run script.py
+
+# Script handles its own dependencies automatically
+./script.py  # If shebang is set
+```
+
+## Metadata Fields
+
+### Required Python Version
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# ///
+```
+
+### Dependencies
+
+```python
+# /// script
+# dependencies = [
+#     "requests",
+#     "click",
+#     "rich",
+# ]
+# ///
+```
+
+### Private Package Index
+
+```python
+# /// script
+# dependencies = ["httpx"]
+#
+# [tool.uv]
+# extra-index-url = ["https://pypi.company.com/simple/"]
+# ///
+```
+
+## Complete Example
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "httpx",
+#     "rich",
+#     "typer",
+# ]
+# ///
+
+"""Fetch and display API data with nice formatting."""
+
+import httpx
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+app = typer.Typer()
+
+
+@app.command()
+def fetch(url: str, format: str = "table"):
+    """Fetch data from URL and display it."""
+    with httpx.Client() as client:
+        response = client.get(url)
+        response.raise_for_status()
+        data = response.json()
+
+    if format == "table" and isinstance(data, list):
+        table = Table()
+        if data:
+            for key in data[0].keys():
+                table.add_column(key)
+            for item in data:
+                table.add_row(*[str(v) for v in item.values()])
+        console.print(table)
+    else:
+        console.print_json(data=data)
+
+
+if __name__ == "__main__":
+    app()
+```
+
+## Creating Scripts with uv
+
+```bash
+# Create new script with metadata
+uv init --script myscript.py
+
+# Add dependency to existing script
+uv add --script myscript.py requests
+
+# Remove dependency from script
+uv remove --script myscript.py requests
+```
+
+## Shebang Options
+
+### Basic (requires uv in PATH)
+
+```python
+#!/usr/bin/env -S uv run --script
+```
+
+### With specific Python version
+
+```python
+#!/usr/bin/env -S uv run --python 3.12 --script
+```
+
+### Quiet mode (suppress uv output)
+
+```python
+#!/usr/bin/env -S uv run --quiet --script
+```
+
+## Examples by Use Case
+
+### Data Processing Script
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pandas", "openpyxl"]
+# ///
+
+import pandas as pd
+import sys
+
+df = pd.read_excel(sys.argv[1])
+print(df.describe())
+```
+
+### Web Scraping Script
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["httpx", "beautifulsoup4", "lxml"]
+# ///
+
+import httpx
+from bs4 import BeautifulSoup
+
+response = httpx.get("https://example.com")
+soup = BeautifulSoup(response.text, "lxml")
+print(soup.title.string)
+```
+
+### CLI Tool Script
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["typer", "rich"]
+# ///
+
+import typer
+from rich import print
+
+app = typer.Typer()
+
+@app.command()
+def greet(name: str):
+    print(f"[green]Hello, {name}![/green]")
+
+if __name__ == "__main__":
+    app()
+```
+
+### Async Script
+
+```python
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["httpx"]
+# ///
+
+import asyncio
+import httpx
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        urls = ["https://api1.example.com", "https://api2.example.com"]
+        tasks = [client.get(url) for url in urls]
+        responses = await asyncio.gather(*tasks)
+        for r in responses:
+            print(r.status_code)
+
+asyncio.run(main())
+```
+
+## Best Practices
+
+1. **Always specify `requires-python`** - Ensures compatibility
+2. **Pin major versions for Python** - Use `>=3.11` not `==3.11`
+3. **Omit version constraints for dependencies** - Use `uv add --script` to add dependencies; let uv select versions
+4. **Keep scripts focused** - One script, one purpose
+5. **Add docstring** - Document what the script does
+6. **Use type hints** - Improves readability and catches errors
+
+## Limitations
+
+- No support for dependency groups
+- No support for editable installs
+- No support for local dependencies (use relative imports)
+- No lockfile (versions may vary between runs)
+
+For projects needing these features, use a full `pyproject.toml` setup instead.

--- a/.agents/skills/modern-python/references/prek.md
+++ b/.agents/skills/modern-python/references/prek.md
@@ -1,0 +1,211 @@
+# prek: Fast Pre-commit Hooks
+
+[prek](https://github.com/j178/prek) is a fast, Rust-native drop-in replacement for pre-commit. It uses the same `.pre-commit-config.yaml` format and is fully compatible with existing configurations.
+
+## Why prek over pre-commit?
+
+| Feature | prek | pre-commit |
+|---------|------|------------|
+| Speed | ~7x faster hook installation | Slower |
+| Dependencies | Single binary, no runtime needed | Requires Python |
+| Disk usage | Shared toolchains between hooks | Isolated environments |
+| Parallelism | Parallel repo cloning and hook execution | Sequential |
+| Python management | Uses uv automatically | Manual Python setup |
+| Monorepo support | Built-in workspace mode | Not supported |
+
+**Already using prek:** CPython, Apache Airflow, FastAPI, Ruff, Home Assistant, and [many more](https://github.com/j178/prek#who-is-using-prek).
+
+## Installation
+
+See [security-setup.md](./security-setup.md#tool-installation) for installation options.
+
+## Quick Start
+
+### For Existing pre-commit Users
+
+prek is fully compatible with `.pre-commit-config.yaml`. Just replace commands:
+
+```bash
+# Instead of: pre-commit install
+prek install
+
+# Instead of: pre-commit run --all-files
+prek run --all-files
+
+# Instead of: pre-commit autoupdate
+prek auto-update
+```
+
+### New Setup
+
+1. Create `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: <latest>  # https://github.com/astral-sh/ruff-pre-commit/releases
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+```
+
+2. Install and run:
+
+```bash
+# Install git hooks
+prek install
+
+# Run manually on all files
+prek run --all-files
+
+# Run specific hook
+prek run ruff
+```
+
+## Configuration
+
+For a complete, copy-paste-ready configuration, see [templates/pre-commit-config.yaml](../templates/pre-commit-config.yaml).
+
+### Recommended `.pre-commit-config.yaml`
+
+> **Note:** Versions shown as `<latest>` are placeholders. Always check the linked releases for current stable versions before use.
+
+```yaml
+# See https://pre-commit.com for more information
+default_language_version:
+  python: python3.12
+
+repos:
+  # Ruff - linting and formatting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: <latest>  # https://github.com/astral-sh/ruff-pre-commit/releases
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # General file checks (prek builtin - faster, no external deps)
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+
+  # Security hooks - see security-setup.md for detailed guidance
+  # Shell script linting
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: <latest>  # https://github.com/koalaman/shellcheck-precommit/tags
+    hooks:
+      - id: shellcheck
+        args: [--severity=error]
+
+  # Secret detection
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: <latest>  # https://github.com/Yelp/detect-secrets/releases
+    hooks:
+      - id: detect-secrets
+        args: [--baseline, .secrets.baseline]
+
+  # GitHub Actions linting
+  - repo: https://github.com/rhysd/actionlint
+    rev: <latest>  # https://github.com/rhysd/actionlint/releases
+    hooks:
+      - id: actionlint
+
+  # GitHub Actions security audit
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: <latest>  # https://github.com/zizmorcore/zizmor-pre-commit/releases
+    hooks:
+      - id: zizmor
+        args: [--persona=regular, --min-severity=medium, --min-confidence=medium]
+```
+
+See [security-setup.md](./security-setup.md) for detailed guidance on each security hook.
+
+### Using Built-in Hooks
+
+prek includes Rust-native implementations of common hooks for extra speed:
+
+```yaml
+repos:
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `prek install` | Install git hooks |
+| `prek uninstall` | Remove git hooks |
+| `prek run` | Run hooks on staged files |
+| `prek run --all-files` | Run on all files |
+| `prek run --last-commit` | Run on last commit's files |
+| `prek run HOOK [HOOK...]` | Run specific hook(s) |
+| `prek run -d src/` | Run on files in directory |
+| `prek auto-update` | Update hook versions |
+| `prek list` | List configured hooks |
+| `prek clean` | Remove cached environments |
+
+## CI Configuration
+
+### GitHub Actions
+
+```yaml
+name: Pre-commit
+on: [push, pull_request]
+
+jobs:
+  prek:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha>  # <latest> https://github.com/actions/checkout/releases
+      - uses: j178/prek-action@<sha>  # <latest> https://github.com/j178/prek-action/releases
+```
+
+Or manually:
+
+```yaml
+- name: Install prek
+  run: uv tool install prek
+
+- name: Run hooks
+  run: prek run --all-files
+```
+
+## Makefile Integration
+
+```makefile
+.PHONY: hooks hooks-install
+
+hooks:
+	prek run --all-files
+
+hooks-install:
+	prek install
+```
+
+## Migration from pre-commit
+
+1. Install prek: `uv tool install prek`
+2. Remove pre-commit: `pip uninstall pre-commit` or `uv tool uninstall pre-commit`
+3. Re-install hooks: `prek install`
+4. (Optional) Clean old environments: `rm -rf ~/.cache/pre-commit`
+
+Your existing `.pre-commit-config.yaml` works unchanged.
+
+## Best Practices
+
+1. **Use `prek run --all-files` in CI** - Ensures all files are checked, not just changed ones
+2. **Pin hook versions** - Use specific `rev` values, not branches
+3. **Use `--cooldown-days` for auto-update** - Mitigates supply chain attacks: `prek auto-update --cooldown-days 7`
+4. **Prefer built-in hooks** - Use `repo: builtin` for common checks (faster, offline)
+5. **Run hooks before commit** - `prek install` sets this up automatically
+6. **Initialize detect-secrets baseline** - Run `detect-secrets scan > .secrets.baseline` before first commit

--- a/.agents/skills/modern-python/references/pyproject.md
+++ b/.agents/skills/modern-python/references/pyproject.md
@@ -1,0 +1,254 @@
+# pyproject.toml Configuration Reference
+
+Complete reference for configuring `pyproject.toml` for modern Python projects.
+
+**Important**: Always use `uv add` and `uv remove` to manage dependencies. Do not edit the `dependencies` or `dependency-groups` sections directly.
+
+## Complete Example
+
+```toml
+[project]
+name = "myproject"
+version = "0.1.0"
+description = "A modern Python project"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+authors = [
+    { name = "Your Name", email = "you@example.com" }
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+dependencies = [
+    "requests",
+    "rich",
+]
+
+[project.optional-dependencies]
+# Use for optional features users can install
+cli = ["typer"]
+
+[project.scripts]
+myproject = "myproject.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/org/myproject"
+Documentation = "https://myproject.readthedocs.io"
+Repository = "https://github.com/org/myproject"
+
+[build-system]
+requires = ["uv_build>=0.9,<1"]  # Use latest 0.x; check https://pypi.org/project/uv-build/
+build-backend = "uv_build"
+
+[dependency-groups]
+dev = ["ruff", "ty"]
+test = ["pytest", "pytest-cov", "hypothesis"]
+docs = ["sphinx", "myst-parser"]
+
+[tool.uv]
+default-groups = ["dev", "test"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+src = ["src"]
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    "D",        # pydocstyle (enable selectively)
+    "COM812",   # trailing comma (conflicts with formatter)
+    "ISC001",   # implicit string concat (conflicts with formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "S101",     # assert allowed in tests
+    "PLR2004",  # magic values allowed in tests
+    "ANN",      # annotations optional in tests
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+
+[tool.pytest]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = [
+    "--cov=myproject",
+    "--cov-report=term-missing",
+    "--cov-fail-under=80",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["src/myproject"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]
+```
+
+## Section Reference
+
+### [project]
+
+Core project metadata following PEP 621.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Package name (lowercase, hyphens) |
+| `version` | Yes | Semantic version |
+| `description` | No | One-line description |
+| `readme` | No | Path to README file |
+| `license` | No | SPDX license identifier |
+| `requires-python` | Recommended | Python version constraint |
+| `authors` | No | List of author dicts |
+| `dependencies` | No | Runtime dependencies |
+
+### [project.optional-dependencies]
+
+**Rarely needed.** Only use for optional *runtime* features that end users install:
+
+```toml
+[project.optional-dependencies]
+# User installs with: uv add myproject[postgres]
+postgres = ["psycopg2"]
+```
+
+**Do NOT use for dev tools**—use `[dependency-groups]` instead.
+
+### [project.scripts]
+
+Console entry points:
+
+```toml
+[project.scripts]
+myproject = "myproject.cli:main"
+myproject-serve = "myproject.server:run"
+```
+
+### [build-system]
+
+Build backend configuration. Use `uv_build` for most projects:
+
+```toml
+[build-system]
+requires = ["uv_build>=0.9,<1"]  # Use latest 0.x; check https://pypi.org/project/uv-build/
+build-backend = "uv_build"
+```
+
+`uv_build` is simpler and sufficient for most use cases. Use static versioning in `[project] version` rather than VCS-aware dynamic versioning.
+
+For flat layout (no `src/` directory), configure the module root:
+
+```toml
+[tool.uv.build-backend]
+module-root = ""
+```
+
+> **Note:** These tools evolve rapidly. Prefer `>=X.Y,<X+1` constraints to automatically get newer releases within the same major version.
+
+### [dependency-groups]
+
+Development dependencies (PEP 735). Unlike optional-dependencies, these are NOT installed by users:
+
+```toml
+[dependency-groups]
+dev = [{include-group = "lint"}, {include-group = "test"}, {include-group = "audit"}]
+lint = ["ruff", "ty"]
+test = ["pytest", "pytest-cov"]
+audit = ["pip-audit"]
+docs = ["sphinx", "myst-parser"]
+```
+
+Install with: `uv sync --group dev --group test`
+
+### [tool.uv]
+
+uv-specific configuration:
+
+```toml
+[tool.uv]
+# Default groups to install with `uv sync`
+default-groups = ["dev", "test"]
+
+# Python version management
+python-preference = "managed"
+```
+
+## Version Specifiers
+
+| Specifier | Meaning |
+|-----------|---------|
+| `>=1.0` | At least version 1.0 |
+| `>=1.0,<2.0` | Version 1.x only |
+| `~=1.4` | Compatible release (>=1.4, <2.0) |
+| `==1.4.*` | Any 1.4.x version |
+
+## uv.lock Handling
+
+| Project Type | uv.lock in Git? | Why |
+|--------------|-----------------|-----|
+| Application | ✅ Commit | Reproducible deploys |
+| Library | ❌ .gitignore | Users resolve their own deps |
+
+## Common Patterns
+
+### Library Package
+
+```toml
+[project]
+dependencies = []  # Minimal runtime deps
+
+[project.optional-dependencies]
+# Optional runtime features (user installs with mylib[async])
+async = ["httpx"]
+
+[dependency-groups]
+dev = ["ruff", "ty"]
+test = ["pytest", "pytest-cov"]
+```
+
+### Application Package
+
+```toml
+[project]
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "sqlalchemy",
+]
+
+[project.scripts]
+myapp = "myapp.main:run"
+
+[dependency-groups]
+dev = ["ruff", "ty", "pytest"]
+```
+
+### CLI Tool
+
+```toml
+[project]
+dependencies = [
+    "typer",
+    "rich",
+]
+
+[project.scripts]
+mytool = "mytool.cli:app"
+
+[dependency-groups]
+dev = ["ruff", "ty", "pytest"]
+```

--- a/.agents/skills/modern-python/references/ruff-config.md
+++ b/.agents/skills/modern-python/references/ruff-config.md
@@ -1,0 +1,240 @@
+# Ruff Configuration Reference
+
+Ruff is an extremely fast Python linter and formatter written in Rust. It replaces flake8, black, isort, pyupgrade, pydocstyle, and many other tools.
+
+## Basic Setup
+
+Add to `pyproject.toml`:
+
+```toml
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+src = ["src"]
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    "D",        # pydocstyle
+    "COM812",   # trailing comma (formatter conflict)
+    "ISC001",   # string concat (formatter conflict)
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+```
+
+## Running Ruff
+
+```bash
+# Lint
+uv run ruff check .
+uv run ruff check --fix .        # Auto-fix
+uv run ruff check --fix --unsafe-fixes .  # Including unsafe fixes
+
+# Format
+uv run ruff format .
+uv run ruff format --check .     # Check only
+uv run ruff format --diff .      # Show diff
+```
+
+## Rule Categories
+
+Using `select = ["ALL"]` enables all rules. Common categories:
+
+| Code | Category | Description |
+|------|----------|-------------|
+| `E`, `W` | pycodestyle | Style errors and warnings |
+| `F` | Pyflakes | Logical errors |
+| `I` | isort | Import sorting |
+| `N` | pep8-naming | Naming conventions |
+| `D` | pydocstyle | Docstring conventions |
+| `UP` | pyupgrade | Python upgrade suggestions |
+| `B` | flake8-bugbear | Bug detection |
+| `S` | flake8-bandit | Security issues |
+| `A` | flake8-builtins | Built-in shadowing |
+| `C4` | flake8-comprehensions | Comprehension improvements |
+| `DTZ` | flake8-datetimez | Timezone-aware datetime |
+| `T10` | flake8-debugger | Debugger statements |
+| `T20` | flake8-print | Print statements |
+| `PT` | flake8-pytest-style | Pytest style |
+| `Q` | flake8-quotes | Quote consistency |
+| `SIM` | flake8-simplify | Simplification suggestions |
+| `TID` | flake8-tidy-imports | Import hygiene |
+| `ARG` | flake8-unused-arguments | Unused arguments |
+| `ERA` | eradicate | Commented-out code |
+| `PL` | Pylint | Pylint rules |
+| `RUF` | Ruff-specific | Ruff's own rules |
+| `ANN` | flake8-annotations | Type annotation checks |
+
+## Recommended Ignores
+
+### Always Ignore (Formatter Conflicts)
+
+```toml
+ignore = [
+    "COM812",   # missing-trailing-comma
+    "ISC001",   # single-line-implicit-string-concatenation
+]
+```
+
+### Common Ignores
+
+```toml
+ignore = [
+    "D",        # Docstrings (enable selectively)
+    "ANN401",   # Dynamically typed Any
+    "TD002",    # Missing TODO author
+    "TD003",    # Missing TODO link
+    "FIX002",   # Line contains TODO
+]
+```
+
+## Per-File Ignores
+
+```toml
+[tool.ruff.lint.per-file-ignores]
+# Tests
+"tests/**/*.py" = [
+    "S101",     # assert usage
+    "PLR2004",  # magic values
+    "ANN",      # type annotations
+    "D",        # docstrings
+]
+
+# Scripts
+"scripts/**/*.py" = [
+    "T20",      # print statements
+    "INP001",   # implicit namespace package
+]
+
+# __init__.py
+"__init__.py" = [
+    "F401",     # unused imports (re-exports)
+]
+
+# Migrations
+"**/migrations/*.py" = [
+    "ALL",      # ignore all
+]
+```
+
+## Import Sorting (isort)
+
+```toml
+[tool.ruff.lint.isort]
+force-single-line = false
+known-first-party = ["myproject"]
+required-imports = ["from __future__ import annotations"]
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder",
+]
+```
+
+## Docstring Style (pydocstyle)
+
+If enabling docstring checks:
+
+```toml
+[tool.ruff.lint]
+select = ["D"]
+ignore = [
+    "D100",     # Missing module docstring
+    "D104",     # Missing public package docstring
+    "D203",     # 1 blank line before class docstring (conflicts D211)
+    "D213",     # Multi-line summary second line (conflicts D212)
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"  # or "numpy", "pep257"
+```
+
+## Formatter Configuration
+
+```toml
+[tool.ruff.format]
+quote-style = "double"           # or "single"
+indent-style = "space"           # or "tab"
+skip-magic-trailing-comma = false
+line-ending = "auto"             # or "lf", "crlf"
+docstring-code-format = true
+docstring-code-line-length = 80
+```
+
+## Type Checking
+
+Ruff does NOT do type checking. Use **ty** (from Astral, the same team behind ruff and uv):
+
+```bash
+# Add ty to dev dependencies
+uv add --group dev ty
+
+# Run type checking
+uv run ty check src/
+```
+
+ty is significantly faster than mypy or pyright and integrates well with the modern Python toolchain.
+
+## CI Configuration
+
+```yaml
+# GitHub Actions
+- name: Lint
+  run: uv run ruff check --output-format=github .
+
+- name: Format check
+  run: uv run ruff format --check .
+```
+
+## Migration from Other Tools
+
+### From flake8
+
+Ruff covers most flake8 plugins. Remove:
+- flake8
+- flake8-* plugins
+- .flake8 config file
+
+### From black
+
+Remove black and use `ruff format`. Remove:
+- black
+- [tool.black] config
+
+### From isort
+
+Ruff includes isort. Remove:
+- isort
+- [tool.isort] config
+
+Use `[tool.ruff.lint.isort]` for isort settings.
+
+## Code Modernization
+
+Run pyupgrade rules to modernize syntax to your target Python version:
+
+```bash
+uv run ruff check --select=UP --fix .  # Auto-fix upgrades
+uv run ruff check --select=UP .        # Preview only
+```
+
+Common modernizations include:
+- `typing.Optional[X]` → `X | None`
+- `typing.List[X]` → `list[X]`
+- `super(ClassName, self)` → `super()`
+- Format strings and other syntax upgrades
+
+## Line Length Migration
+
+If migrating from 120 to 100 char lines, expect manual fixes.
+For less churn during initial migration, keep existing:
+
+```toml
+line-length = 120  # Match existing; tighten later
+```

--- a/.agents/skills/modern-python/references/security-setup.md
+++ b/.agents/skills/modern-python/references/security-setup.md
@@ -1,0 +1,255 @@
+# Security Setup
+
+Security tooling for Python projects: pre-commit hooks, CI auditing, and dependency scanning.
+
+## Tool Installation
+
+Install these tools before running the quick setup commands below.
+
+### prek (pre-commit runner)
+
+```bash
+# Homebrew (recommended)
+brew install prek
+
+# Cargo
+cargo install prek
+
+# Standalone installer
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/j178/prek/releases/latest/download/prek-installer.sh | sh
+```
+
+### Security tools
+
+Pre-commit hooks auto-install tools when run via prek. For manual CLI usage:
+
+```bash
+# Homebrew (macOS/Linux)
+brew install actionlint shellcheck
+
+# Python tools via uv
+uv tool install detect-secrets
+uv tool install zizmor
+```
+
+Alternative installation methods:
+
+- **actionlint**: `go install github.com/rhysd/actionlint/cmd/actionlint@latest`
+- **zizmor**: `cargo install zizmor`
+- **detect-secrets**: `pipx install detect-secrets`
+
+## Quick Setup
+
+```bash
+# 1. Install security hooks
+prek install
+
+# 2. Initialize secrets baseline
+detect-secrets scan > .secrets.baseline
+
+# 3. Audit existing workflows
+actionlint .github/workflows/
+zizmor .github/workflows/
+```
+
+See [templates/pre-commit-config.yaml](../templates/pre-commit-config.yaml) for a complete hook configuration.
+
+## Tool Matrix
+
+| Tool | Runs | Catches |
+|------|------|---------|
+| **shellcheck** | pre-commit | Shell script bugs, quoting issues |
+| **detect-secrets** | pre-commit | Leaked API keys, passwords, tokens |
+| **actionlint** | pre-commit, CI | Workflow syntax errors, invalid refs |
+| **zizmor** | pre-commit, CI | Workflow security issues, excessive permissions |
+| **pip-audit** | CI, manual | Known CVEs in dependencies |
+| **Dependabot** | scheduled | Outdated dependencies with vulnerabilities |
+
+## Pre-commit Hooks
+
+These run locally before each commit via prek.
+
+### shellcheck - Shell Script Linting
+
+Catches common shell scripting errors: unquoted variables, undefined variables, deprecated syntax.
+
+```yaml
+# In .pre-commit-config.yaml
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: <latest>  # https://github.com/koalaman/shellcheck-precommit/tags
+  hooks:
+    - id: shellcheck
+      args: [--severity=error]  # Start strict, adjust if needed
+```
+
+Common findings:
+- `SC2086`: Unquoted variable expansion (word splitting risk)
+- `SC2046`: Unquoted command substitution
+- `SC2155`: Declare and assign separately to avoid masking return values
+
+### detect-secrets - Secret Detection
+
+Prevents accidentally committing API keys, passwords, and tokens.
+
+```yaml
+- repo: https://github.com/Yelp/detect-secrets
+  rev: <latest>  # https://github.com/Yelp/detect-secrets/releases
+  hooks:
+    - id: detect-secrets
+      args: [--baseline, .secrets.baseline]
+```
+
+**First-time setup:**
+
+```bash
+# Generate baseline of existing "secrets" (false positives to ignore)
+detect-secrets scan > .secrets.baseline
+
+# Review the baseline - ensure no real secrets
+cat .secrets.baseline
+
+# Commit the baseline
+git add .secrets.baseline
+```
+
+**When hook fails:**
+
+```bash
+# View the finding (non-interactive)
+detect-secrets audit --report .secrets.baseline
+```
+
+If false positive: update baseline with `detect-secrets scan --update .secrets.baseline`
+If real secret: remove from code and rotate the credential.
+
+## CI Security
+
+These run in GitHub Actions on every push/PR.
+
+### actionlint - Workflow Syntax Validation
+
+Catches syntax errors, invalid action references, and type mismatches before they fail in CI.
+
+```yaml
+- repo: https://github.com/rhysd/actionlint
+  rev: <latest>  # https://github.com/rhysd/actionlint/releases
+  hooks:
+    - id: actionlint
+```
+
+Run manually:
+
+```bash
+actionlint .github/workflows/
+```
+
+Common findings:
+- Invalid event triggers
+- Undefined workflow inputs
+- Shell syntax errors in `run:` blocks
+- Invalid action version references
+
+### zizmor - Workflow Security Audit
+
+Finds security issues in GitHub Actions workflows: excessive permissions, injection risks, untrusted inputs.
+
+```yaml
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: <latest>  # https://github.com/zizmorcore/zizmor-pre-commit/releases
+  hooks:
+    - id: zizmor
+      args: [--persona=regular, --min-severity=medium, --min-confidence=medium]
+```
+
+Run manually:
+
+```bash
+zizmor .github/workflows/
+```
+
+**Fixing `excessive-permissions`:**
+
+By default, workflows get `write` access to everything. Lock down with explicit permissions:
+
+```yaml
+# Read-only workflows (lint, test, audit)
+permissions:
+  contents: read
+
+# Workflows that push or create releases
+permissions:
+  contents: write
+
+# Workflows that comment on PRs
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+Common findings:
+- `excessive-permissions`: No `permissions:` block
+- `template-injection`: Using `${{ github.event.* }}` unsafely
+- `unpinned-action`: Actions not pinned to SHA
+- `dangerous-triggers`: `pull_request_target` with checkout
+
+## Dependency Security
+
+### pip-audit - Vulnerability Scanning
+
+Checks installed packages against the Python Advisory Database (PyPA) for known CVEs.
+
+**Setup:**
+
+```toml
+# pyproject.toml
+[dependency-groups]
+audit = ["pip-audit"]
+```
+
+**Usage:**
+
+```bash
+# Audit current environment
+uv run pip-audit
+
+# Audit without installing (faster for CI)
+uv run pip-audit .
+
+# Fix automatically (upgrades vulnerable packages)
+uv run pip-audit --fix
+```
+
+**In CI:**
+
+```yaml
+- name: Security audit
+  run: uv run pip-audit .
+```
+
+**When vulnerabilities found:**
+
+1. Check if the CVE affects your usage (many are in unused code paths)
+2. Update the package: `uv add <package>@latest`
+3. If no fix available: evaluate risk, consider alternatives, or add to ignore list
+
+### Dependabot - Automated Updates
+
+Automatically creates PRs for outdated dependencies.
+
+Copy [templates/dependabot.yml](../templates/dependabot.yml) to `.github/dependabot.yml`.
+
+**How pip-audit and Dependabot work together:**
+
+| Tool | Trigger | Scope |
+|------|---------|-------|
+| pip-audit | Every CI run | Known CVEs in current deps |
+| Dependabot | Weekly schedule | All outdated deps, security + non-security |
+
+- **pip-audit** catches: "You have a vulnerable version right now"
+- **Dependabot** prevents: "You'll fall behind and accumulate vulnerabilities"
+
+The 7-day cooldown protects against attackers publishing malicious updates and hoping for quick adoption before detection.
+
+See [dependabot.md](./dependabot.md) for advanced configuration.
+
+See [prek.md](./prek.md) for complete pre-commit hook configuration including security hooks.

--- a/.agents/skills/modern-python/references/testing.md
+++ b/.agents/skills/modern-python/references/testing.md
@@ -1,0 +1,284 @@
+# Testing with pytest
+
+Configuration and best practices for pytest with coverage enforcement.
+
+## Setup
+
+Add test dependencies:
+
+```bash
+uv add --group test pytest pytest-cov hypothesis
+```
+
+## pyproject.toml Configuration
+
+```toml
+[tool.pytest]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = [
+    "-ra",                      # Show summary of all test outcomes
+    "--strict-markers",         # Error on unknown markers
+    "--strict-config",          # Error on config issues
+    "--cov=myproject",          # Coverage for package
+    "--cov-report=term-missing", # Show missing lines
+    "--cov-fail-under=80",      # Minimum coverage
+]
+markers = [
+    "slow: marks tests as slow",
+    "integration: marks integration tests",
+]
+filterwarnings = [
+    "error",                    # Treat warnings as errors
+    "ignore::DeprecationWarning:third_party.*",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["src/myproject"]
+omit = [
+    "*/__main__.py",
+    "*/conftest.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+    "@abstractmethod",
+]
+fail_under = 80
+show_missing = true
+```
+
+## Project Structure
+
+```
+myproject/
+├── src/
+│   └── myproject/
+│       ├── __init__.py
+│       └── core.py
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py          # Shared fixtures
+│   ├── test_core.py
+│   └── integration/
+│       └── test_api.py
+└── pyproject.toml
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run with verbose output
+uv run pytest -v
+
+# Run specific file
+uv run pytest tests/test_core.py
+
+# Run specific test
+uv run pytest tests/test_core.py::test_function_name
+
+# Run tests matching pattern
+uv run pytest -k "test_parse"
+
+# Run marked tests
+uv run pytest -m "not slow"
+
+# Stop on first failure
+uv run pytest -x
+
+# Run last failed
+uv run pytest --lf
+```
+
+## Coverage Commands
+
+```bash
+# Run with coverage
+uv run pytest --cov=myproject
+
+# Generate HTML report
+uv run pytest --cov=myproject --cov-report=html
+open htmlcov/index.html
+
+# Coverage without running tests (use existing data)
+uv run coverage report
+uv run coverage html
+```
+
+## Writing Tests
+
+### Basic Test
+
+```python
+# tests/test_core.py
+from myproject.core import add_numbers
+
+def test_add_numbers():
+    assert add_numbers(2, 3) == 5
+
+def test_add_negative():
+    assert add_numbers(-1, 1) == 0
+```
+
+### Using Fixtures
+
+```python
+# tests/conftest.py
+import pytest
+from myproject.db import Database
+
+@pytest.fixture
+def db():
+    """Provide a test database."""
+    database = Database(":memory:")
+    database.init()
+    yield database
+    database.close()
+
+@pytest.fixture
+def sample_data(db):
+    """Populate database with sample data."""
+    db.insert({"name": "test"})
+    return db
+```
+
+```python
+# tests/test_db.py
+def test_query(sample_data):
+    result = sample_data.query("test")
+    assert result is not None
+```
+
+### Parametrized Tests
+
+```python
+import pytest
+
+@pytest.mark.parametrize("input,expected", [
+    ("hello", 5),
+    ("", 0),
+    ("test", 4),
+])
+def test_string_length(input, expected):
+    assert len(input) == expected
+```
+
+### Testing Exceptions
+
+```python
+import pytest
+from myproject.core import divide
+
+def test_divide_by_zero():
+    with pytest.raises(ZeroDivisionError):
+        divide(1, 0)
+
+def test_divide_by_zero_message():
+    with pytest.raises(ZeroDivisionError, match="division by zero"):
+        divide(1, 0)
+```
+
+### Async Tests
+
+```bash
+uv add --group test pytest-asyncio
+```
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_async_function():
+    result = await fetch_data()
+    assert result is not None
+```
+
+## Property-Based Testing with Hypothesis
+
+```bash
+uv add --group test hypothesis
+```
+
+```python
+from hypothesis import given, strategies as st
+from myproject.core import reverse_string
+
+@given(st.text())
+def test_reverse_is_reversible(s):
+    assert reverse_string(reverse_string(s)) == s
+
+@given(st.integers(), st.integers())
+def test_add_commutative(a, b):
+    assert add(a, b) == add(b, a)
+```
+
+## Markers
+
+```python
+import pytest
+
+@pytest.mark.slow
+def test_slow_operation():
+    # Long running test
+    pass
+
+@pytest.mark.integration
+def test_api_call():
+    # Requires external service
+    pass
+
+@pytest.mark.skip(reason="Not implemented yet")
+def test_future_feature():
+    pass
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix only")
+def test_unix_feature():
+    pass
+```
+
+## CI Configuration
+
+```yaml
+# GitHub Actions
+- name: Checkout
+  uses: actions/checkout@<sha>  # <latest> https://github.com/actions/checkout/releases
+
+- name: Run tests
+  run: |
+    uv sync --group test
+    uv run pytest --cov-report=xml
+
+- name: Security audit
+  run: |
+    uv sync --group audit
+    uv run pip-audit
+
+- name: Upload coverage
+  uses: codecov/codecov-action@<sha>  # <latest> https://github.com/codecov/codecov-action/releases
+  with:
+    files: ./coverage.xml
+```
+
+## Makefile Target
+
+```makefile
+.PHONY: test
+
+test:
+	uv run pytest
+
+test-cov:
+	uv run pytest --cov-report=html
+	open htmlcov/index.html
+
+test-fast:
+	uv run pytest -x -q --no-cov
+```

--- a/.agents/skills/modern-python/references/uv-commands.md
+++ b/.agents/skills/modern-python/references/uv-commands.md
@@ -1,0 +1,200 @@
+# uv Command Reference
+
+`uv` is an extremely fast Python package and project manager written in Rust. It replaces pip, virtualenv, pip-tools, pipx, and pyenv.
+
+**Key principle:** Always use `uv run` to execute commands. Never manually activate virtual environments.
+
+## Installation
+
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# Homebrew
+brew install uv
+
+# pipx
+pipx install uv
+```
+
+## Project Commands
+
+### Initialize Projects
+
+| Command | Description |
+|---------|-------------|
+| `uv init` | Create new project (application) |
+| `uv init --package` | Create distributable package with src/ layout |
+| `uv init --lib` | Create library package |
+| `uv init --script file.py` | Create script with PEP 723 metadata |
+
+### Dependency Management
+
+| Command | Description |
+|---------|-------------|
+| `uv add <pkg>` | Add dependency to project |
+| `uv add <pkg> --group dev` | Add to dependency group |
+| `uv add <pkg> --optional feature` | Add to optional dependency |
+| `uv remove <pkg>` | Remove dependency |
+| `uv lock` | Update lock file without installing |
+
+### Environment Management
+
+uv manages virtual environments automatically. Do not manually create or activate venvs.
+
+| Command | Description |
+|---------|-------------|
+| `uv sync` | Install dependencies (creates venv if needed) |
+| `uv sync --all-groups` | Install all dependency groups |
+| `uv sync --group dev` | Install specific group |
+| `uv sync --frozen` | Install from lock file exactly |
+
+### Running Code
+
+| Command | Description |
+|---------|-------------|
+| `uv run <cmd>` | Run command in project venv |
+| `uv run python script.py` | Run Python script |
+| `uv run pytest` | Run pytest |
+| `uv run --with pkg cmd` | Run with temporary dependency |
+
+### Building & Publishing
+
+| Command | Description |
+|---------|-------------|
+| `uv build` | Build wheel and sdist |
+| `uv build --wheel` | Build wheel only |
+| `uv build --sdist` | Build sdist only |
+| `uv publish` | Publish to PyPI |
+| `uv publish --token $TOKEN` | Publish with API token |
+
+## Tool Commands
+
+Run Python tools without installing globally:
+
+```bash
+# Run any tool
+uv tool run ruff check .
+uvx ruff check .  # shorthand
+
+# Install tool globally
+uv tool install ruff
+
+# List installed tools
+uv tool list
+
+# Upgrade tool
+uv tool upgrade ruff
+```
+
+## Python Version Management
+
+```bash
+# Install Python version
+uv python install 3.12
+
+# List available versions
+uv python list
+
+# Pin project to Python version
+uv python pin 3.12
+
+# Use specific version
+uv run --python 3.11 pytest
+```
+
+## Script Commands (PEP 723)
+
+```bash
+# Create script with inline metadata
+uv init --script myscript.py
+
+# Add dependency to script
+uv add --script myscript.py requests
+
+# Run script (auto-installs deps)
+uv run myscript.py
+```
+
+## Common Workflows
+
+### New Application Project
+
+```bash
+uv init myapp
+cd myapp
+uv add fastapi uvicorn
+uv add --group dev ruff pytest
+uv sync --all-groups
+uv run uvicorn myapp:app
+```
+
+### New Library Package
+
+```bash
+uv init --package mylib
+cd mylib
+uv add --group dev ruff pytest pytest-cov
+uv add --group docs sphinx
+uv sync --all-groups
+uv run pytest
+uv build
+```
+
+### Add Tool to Existing Project
+
+```bash
+cd existing-project
+uv add --group dev ruff
+uv run ruff check .
+```
+
+### One-off Script Execution
+
+```bash
+# Run script with dependencies (no project needed)
+uv run --with requests --with rich script.py
+
+# Or use PEP 723 inline metadata
+uv run script_with_metadata.py
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `UV_CACHE_DIR` | Cache directory location |
+| `UV_NO_CACHE` | Disable caching |
+| `UV_PYTHON` | Default Python version |
+| `UV_PROJECT` | Project directory path |
+| `UV_PROJECT_ENVIRONMENT` | Custom venv directory (e.g., `.venv-dev`) |
+| `UV_SYSTEM_PYTHON` | Use system Python |
+
+## Container/Host Development
+
+When developing on a host machine while also running in containers, you can use separate venvs to avoid rebuilding on each context switch:
+
+```bash
+# On host machine (add to shell profile or .envrc)
+export UV_PROJECT_ENVIRONMENT=.venv-dev
+
+# Now host uses .venv-dev, containers use default .venv
+uv sync  # creates .venv-dev on host
+```
+
+Add both to `.gitignore`:
+```
+.venv/
+.venv-dev/
+```
+
+This avoids rebuilding the venv when switching between host and container (different OS, Python versions, or native dependencies).
+
+## Performance Tips
+
+- uv caches aggressively; first install may be slower
+- Use `uv sync --frozen` in CI for reproducible builds
+- Use `uv cache clean` if cache grows too large

--- a/.agents/skills/modern-python/templates/dependabot.yml
+++ b/.agents/skills/modern-python/templates/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot configuration for Python projects
+# Copy to .github/dependabot.yml
+#
+# See references/dependabot.md for advanced configuration.
+
+version: 2
+updates:
+  # Python dependencies (pyproject.toml, requirements.txt)
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    # 7-day cooldown: don't update packages published < 7 days ago
+    # Mitigates supply chain attacks via malicious updates
+    cooldown:
+      default-days: 7
+    # Group minor/patch updates to reduce PR noise
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types: [minor, patch]
+      production-dependencies:
+        dependency-type: production
+        update-types: [patch]
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
+        update-types: [minor, patch]

--- a/.agents/skills/modern-python/templates/pre-commit-config.yaml
+++ b/.agents/skills/modern-python/templates/pre-commit-config.yaml
@@ -1,0 +1,66 @@
+# Pre-commit configuration for Python projects
+# Copy to your repo root as .pre-commit-config.yaml
+#
+# IMPORTANT: Replace all <latest> placeholders with actual versions.
+# Check each linked releases page for current stable versions.
+#
+# Usage:
+#   prek install        # Install git hooks
+#   prek run --all-files  # Run on all files
+#
+# See references/prek.md for more commands.
+
+default_language_version:
+  python: python3.12
+
+repos:
+  # === Code Quality ===
+
+  # Ruff - linting and formatting (replaces black, isort, flake8, pylint)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: <latest>  # https://github.com/astral-sh/ruff-pre-commit/releases
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # === General File Checks ===
+  # prek builtin hooks - faster, no external deps
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+
+  # === Security Hooks ===
+  # See references/security-setup.md for detailed guidance on each hook.
+
+  # Shell script linting - catches unquoted vars, undefined vars, deprecated syntax
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: <latest>  # https://github.com/koalaman/shellcheck-precommit/tags
+    hooks:
+      - id: shellcheck
+        args: [--severity=error]
+
+  # Secret detection - prevents committing API keys, passwords, tokens
+  # Run `detect-secrets scan > .secrets.baseline` before first commit
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: <latest>  # https://github.com/Yelp/detect-secrets/releases
+    hooks:
+      - id: detect-secrets
+        args: [--baseline, .secrets.baseline]
+
+  # GitHub Actions linting - catches syntax errors, invalid refs
+  - repo: https://github.com/rhysd/actionlint
+    rev: <latest>  # https://github.com/rhysd/actionlint/releases
+    hooks:
+      - id: actionlint
+
+  # GitHub Actions security audit - excessive permissions, injection risks
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: <latest>  # https://github.com/zizmorcore/zizmor-pre-commit/releases
+    hooks:
+      - id: zizmor
+        args: [--persona=regular, --min-severity=medium, --min-confidence=medium]

--- a/.agents/skills/prd/SKILL.md
+++ b/.agents/skills/prd/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: prd
+description: 'Generate high-quality Product Requirements Documents (PRDs) for software systems and AI-powered features. Includes executive summaries, user stories, technical specifications, and risk analysis.'
+license: MIT
+---
+
+# Product Requirements Document (PRD)
+
+## Overview
+
+Design comprehensive, production-grade Product Requirements Documents (PRDs) that bridge the gap between business vision and technical execution. This skill works for modern software systems, ensuring that requirements are clearly defined.
+
+## When to Use
+
+Use this skill when:
+
+- Starting a new product or feature development cycle
+- Translating a vague idea into a concrete technical specification
+- Defining requirements for AI-powered features
+- Stakeholders need a unified "source of truth" for project scope
+- User asks to "write a PRD", "document requirements", or "plan a feature"
+
+---
+
+## Operational Workflow
+
+### Phase 1: Discovery (The Interview)
+
+Before writing a single line of the PRD, you **MUST** interrogate the user to fill knowledge gaps. Do not assume context.
+
+**Ask about:**
+
+- **The Core Problem**: Why are we building this now?
+- **Success Metrics**: How do we know it worked?
+- **Constraints**: Budget, tech stack, or deadline?
+
+### Phase 2: Analysis & Scoping
+
+Synthesize the user's input. Identify dependencies and hidden complexities.
+
+- Map out the **User Flow**.
+- Define **Non-Goals** to protect the timeline.
+
+### Phase 3: Technical Drafting
+
+Generate the document using the **Strict PRD Schema** below.
+
+---
+
+## PRD Quality Standards
+
+### Requirements Quality
+
+Use concrete, measurable criteria. Avoid "fast", "easy", or "intuitive".
+
+```diff
+# Vague (BAD)
+- The search should be fast and return relevant results.
+- The UI must look modern and be easy to use.
+
+# Concrete (GOOD)
++ The search must return results within 200ms for a 10k record dataset.
++ The search algorithm must achieve >= 85% Precision@10 in benchmark evals.
++ The UI must follow the 'Vercel/Next.js' design system and achieve 100% Lighthouse Accessibility score.
+```
+
+---
+
+## Strict PRD Schema
+
+You **MUST** follow this exact structure for the output:
+
+### 1. Executive Summary
+
+- **Problem Statement**: 1-2 sentences on the pain point.
+- **Proposed Solution**: 1-2 sentences on the fix.
+- **Success Criteria**: 3-5 measurable KPIs.
+
+### 2. User Experience & Functionality
+
+- **User Personas**: Who is this for?
+- **User Stories**: `As a [user], I want to [action] so that [benefit].`
+- **Acceptance Criteria**: Bulleted list of "Done" definitions for each story.
+- **Non-Goals**: What are we NOT building?
+
+### 3. AI System Requirements (If Applicable)
+
+- **Tool Requirements**: What tools and APIs are needed?
+- **Evaluation Strategy**: How to measure output quality and accuracy.
+
+### 4. Technical Specifications
+
+- **Architecture Overview**: Data flow and component interaction.
+- **Integration Points**: APIs, DBs, and Auth.
+- **Security & Privacy**: Data handling and compliance.
+
+### 5. Risks & Roadmap
+
+- **Phased Rollout**: MVP -> v1.1 -> v2.0.
+- **Technical Risks**: Latency, cost, or dependency failures.
+
+---
+
+## Implementation Guidelines
+
+### DO (Always)
+
+- **Define Testing**: For AI systems, specify how to test and validate output quality.
+- **Iterate**: Present a draft and ask for feedback on specific sections.
+
+### DON'T (Avoid)
+
+- **Skip Discovery**: Never write a PRD without asking at least 2 clarifying questions first.
+- **Hallucinate Constraints**: If the user didn't specify a tech stack, ask or label it as `TBD`.
+
+---
+
+## Example: Intelligent Search System
+
+### 1. Executive Summary
+
+**Problem**: Users struggle to find specific documentation snippets in massive repositories.
+**Solution**: An intelligent search system that provides direct answers with source citations.
+**Success**:
+
+- Reduce search time by 50%.
+- Citation accuracy >= 95%.
+
+### 2. User Stories
+
+- **Story**: As a developer, I want to ask natural language questions so I don't have to guess keywords.
+- **AC**:
+  - Supports multi-turn clarification.
+  - Returns code blocks with "Copy" button.
+
+### 3. AI System Architecture
+
+- **Tools Required**: `codesearch`, `grep`, `webfetch`.
+
+### 4. Evaluation
+
+- **Benchmark**: Test with 50 common developer questions.
+- **Pass Rate**: 90% must match expected citations.

--- a/.agents/skills/python-typing-ops/SKILL.md
+++ b/.agents/skills/python-typing-ops/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: python-typing-ops
+description: "Python type hints and type safety patterns. Triggers on: type hints, typing, TypeVar, Generic, Protocol, mypy, pyright, type annotation, overload, TypedDict."
+compatibility: "Python 3.10+ (uses union syntax X | Y). Some patterns require 3.11+ (Self, TypeVarTuple)."
+allowed-tools: "Read Write"
+depends-on: []
+related-skills: [python-pytest-ops]
+---
+
+# Python Typing Patterns
+
+Modern type hints for safe, documented Python code.
+
+## Basic Annotations
+
+```python
+# Variables
+name: str = "Alice"
+count: int = 42
+items: list[str] = ["a", "b"]
+mapping: dict[str, int] = {"key": 1}
+
+# Function signatures
+def greet(name: str, times: int = 1) -> str:
+    return f"Hello, {name}!" * times
+
+# None handling
+def find(id: int) -> str | None:
+    return db.get(id)  # May return None
+```
+
+## Collections
+
+```python
+from collections.abc import Sequence, Mapping, Iterable
+
+# Use collection ABCs for flexibility
+def process(items: Sequence[str]) -> list[str]:
+    """Accepts list, tuple, or any sequence."""
+    return [item.upper() for item in items]
+
+def lookup(data: Mapping[str, int], key: str) -> int:
+    """Accepts dict or any mapping."""
+    return data.get(key, 0)
+
+# Nested types
+Matrix = list[list[float]]
+Config = dict[str, str | int | bool]
+```
+
+## Optional and Union
+
+```python
+# Modern syntax (3.10+)
+def find(id: int) -> User | None:
+    pass
+
+def parse(value: str | int | float) -> str:
+    pass
+
+# With default None
+def fetch(url: str, timeout: float | None = None) -> bytes:
+    pass
+```
+
+## TypedDict
+
+```python
+from typing import TypedDict, Required, NotRequired
+
+class UserDict(TypedDict):
+    id: int
+    name: str
+    email: str | None
+
+class ConfigDict(TypedDict, total=False):  # All optional
+    debug: bool
+    log_level: str
+
+class APIResponse(TypedDict):
+    data: Required[list[dict]]
+    error: NotRequired[str]
+
+def process_user(user: UserDict) -> str:
+    return user["name"]  # Type-safe key access
+```
+
+## Callable
+
+```python
+from collections.abc import Callable
+
+# Function type
+Handler = Callable[[str, int], bool]
+
+def register(callback: Callable[[str], None]) -> None:
+    pass
+
+# With keyword args (use Protocol instead)
+from typing import Protocol
+
+class Processor(Protocol):
+    def __call__(self, data: str, *, verbose: bool = False) -> int:
+        ...
+```
+
+## Generics
+
+```python
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def first(items: list[T]) -> T | None:
+    return items[0] if items else None
+
+# Bounded TypeVar
+from typing import SupportsFloat
+
+N = TypeVar("N", bound=SupportsFloat)
+
+def average(values: list[N]) -> float:
+    return sum(float(v) for v in values) / len(values)
+```
+
+## Protocol (Structural Typing)
+
+```python
+from typing import Protocol
+
+class Readable(Protocol):
+    def read(self, n: int = -1) -> bytes:
+        ...
+
+def load(source: Readable) -> dict:
+    """Accepts any object with read() method."""
+    data = source.read()
+    return json.loads(data)
+
+# Works with file, BytesIO, custom classes
+load(open("data.json", "rb"))
+load(io.BytesIO(b"{}"))
+```
+
+## Type Guards
+
+```python
+from typing import TypeGuard
+
+def is_string_list(val: list[object]) -> TypeGuard[list[str]]:
+    return all(isinstance(x, str) for x in val)
+
+def process(items: list[object]) -> None:
+    if is_string_list(items):
+        # items is now list[str]
+        print(", ".join(items))
+```
+
+## Literal and Final
+
+```python
+from typing import Literal, Final
+
+Mode = Literal["read", "write", "append"]
+
+def open_file(path: str, mode: Mode) -> None:
+    pass
+
+# Constants
+MAX_SIZE: Final = 1024
+API_VERSION: Final[str] = "v2"
+```
+
+## Quick Reference
+
+| Type | Use Case |
+|------|----------|
+| `X \| None` | Optional value |
+| `list[T]` | Homogeneous list |
+| `dict[K, V]` | Dictionary |
+| `Callable[[Args], Ret]` | Function type |
+| `TypeVar("T")` | Generic parameter |
+| `Protocol` | Structural typing |
+| `TypedDict` | Dict with fixed keys |
+| `Literal["a", "b"]` | Specific values only |
+| `Final` | Cannot be reassigned |
+
+## Type Checker Commands
+
+```bash
+# mypy
+mypy src/ --strict
+
+# pyright
+pyright src/
+
+# In pyproject.toml
+[tool.mypy]
+strict = true
+python_version = "3.11"
+```
+
+## Additional Resources
+
+- `./references/generics-advanced.md` - TypeVar, ParamSpec, TypeVarTuple
+- `./references/protocols-patterns.md` - Structural typing, runtime protocols
+- `./references/type-narrowing.md` - Guards, isinstance, assert
+- `./references/mypy-config.md` - mypy/pyright configuration
+- `./references/runtime-validation.md` - Pydantic v2, typeguard, beartype
+- `./references/overloads.md` - @overload decorator patterns
+
+## Scripts
+
+- `./scripts/check-types.sh` - Run type checkers with common options
+
+## Assets
+
+- `./assets/pyproject-typing.toml` - Recommended mypy/pyright config
+
+---
+
+## See Also
+
+This is a **foundation skill** with no prerequisites.
+
+**Related Skills:**
+- `python-pytest-ops` - Type-safe fixtures and mocking
+
+**Build on this skill:**
+- `python-async-ops` - Async type annotations
+- `python-fastapi-ops` - Pydantic models and validation
+- `python-database-ops` - SQLAlchemy type annotations

--- a/.agents/skills/python-typing-ops/assets/pyproject-typing.toml
+++ b/.agents/skills/python-typing-ops/assets/pyproject-typing.toml
@@ -1,0 +1,117 @@
+# pyproject.toml - Type checker configuration
+# Copy these sections to your pyproject.toml
+
+# ============================================================
+# mypy Configuration
+# ============================================================
+
+[tool.mypy]
+# Python version to target
+python_version = "3.11"
+
+# Enable strict mode (recommended for new projects)
+strict = true
+
+# Additional strictness
+warn_return_any = true
+warn_unused_ignores = true
+warn_unreachable = true
+
+# Error reporting
+show_error_codes = true
+show_error_context = true
+show_column_numbers = true
+pretty = true
+
+# Paths
+files = ["src", "tests"]
+exclude = [
+    "migrations/",
+    "venv/",
+    ".venv/",
+    "__pycache__/",
+    "build/",
+    "dist/",
+]
+
+# Plugin support (uncomment as needed)
+# plugins = [
+#     "pydantic.mypy",
+#     "sqlalchemy.ext.mypy.plugin",
+# ]
+
+# ============================================================
+# Per-module overrides
+# ============================================================
+
+# Relax strictness for tests
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_untyped_calls = false
+
+# Ignore missing stubs for common libraries
+[[tool.mypy.overrides]]
+module = [
+    "requests.*",
+    "boto3.*",
+    "botocore.*",
+    "celery.*",
+    "redis.*",
+]
+ignore_missing_imports = true
+
+# Legacy code - gradually add types
+# [[tool.mypy.overrides]]
+# module = "legacy.*"
+# ignore_errors = true
+
+
+# ============================================================
+# pyright Configuration
+# ============================================================
+
+[tool.pyright]
+# Python version
+pythonVersion = "3.11"
+
+# Paths
+include = ["src"]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    "venv",
+    ".venv",
+    "build",
+    "dist",
+]
+
+# Type checking mode: off, basic, standard, strict
+typeCheckingMode = "strict"
+
+# Report settings (strict mode enables all by default)
+reportMissingTypeStubs = false
+reportUnusedImport = "warning"
+reportUnusedVariable = "warning"
+reportUnusedFunction = "warning"
+
+# Useful additional checks
+reportUninitializedInstanceVariable = true
+reportIncompatibleMethodOverride = true
+reportIncompatibleVariableOverride = true
+
+
+# ============================================================
+# Recommended dev dependencies
+# ============================================================
+
+# [project.optional-dependencies]
+# dev = [
+#     "mypy>=1.8.0",
+#     "pyright>=1.1.350",
+#     # Common type stubs
+#     "types-requests",
+#     "types-redis",
+#     "types-PyYAML",
+#     "types-python-dateutil",
+# ]

--- a/.agents/skills/python-typing-ops/references/generics-advanced.md
+++ b/.agents/skills/python-typing-ops/references/generics-advanced.md
@@ -1,0 +1,282 @@
+# Advanced Generics
+
+Deep dive into Python's generic type system.
+
+## TypeVar Basics
+
+```python
+from typing import TypeVar
+
+# Unconstrained TypeVar
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+# Usage - type is preserved
+reveal_type(identity(42))      # int
+reveal_type(identity("hello")) # str
+```
+
+## Bounded TypeVar
+
+```python
+from typing import TypeVar
+
+# Upper bound - T must be subtype of bound
+class Animal:
+    def speak(self) -> str:
+        return "..."
+
+class Dog(Animal):
+    def speak(self) -> str:
+        return "woof"
+
+A = TypeVar("A", bound=Animal)
+
+def make_speak(animal: A) -> A:
+    print(animal.speak())
+    return animal
+
+# Works with Animal or any subclass
+dog = make_speak(Dog())  # Returns Dog, not Animal
+```
+
+## Constrained TypeVar
+
+```python
+from typing import TypeVar
+
+# Constrained to specific types
+StrOrBytes = TypeVar("StrOrBytes", str, bytes)
+
+def concat(a: StrOrBytes, b: StrOrBytes) -> StrOrBytes:
+    return a + b
+
+# Must be same type
+concat("a", "b")     # OK -> str
+concat(b"a", b"b")   # OK -> bytes
+# concat("a", b"b")  # Error: can't mix
+```
+
+## Generic Classes
+
+```python
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Stack(Generic[T]):
+    def __init__(self) -> None:
+        self._items: list[T] = []
+
+    def push(self, item: T) -> None:
+        self._items.append(item)
+
+    def pop(self) -> T:
+        return self._items.pop()
+
+    def peek(self) -> T | None:
+        return self._items[-1] if self._items else None
+
+# Usage
+int_stack: Stack[int] = Stack()
+int_stack.push(1)
+int_stack.push(2)
+value = int_stack.pop()  # int
+
+str_stack: Stack[str] = Stack()
+str_stack.push("hello")
+```
+
+## Multiple Type Parameters
+
+```python
+from typing import Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+class Pair(Generic[K, V]):
+    def __init__(self, key: K, value: V) -> None:
+        self.key = key
+        self.value = value
+
+    def swap(self) -> "Pair[V, K]":
+        return Pair(self.value, self.key)
+
+pair: Pair[str, int] = Pair("age", 30)
+swapped = pair.swap()  # Pair[int, str]
+```
+
+## Self Type (Python 3.11+)
+
+```python
+from typing import Self
+
+class Builder:
+    def __init__(self) -> None:
+        self.value = ""
+
+    def add(self, text: str) -> Self:
+        self.value += text
+        return self
+
+    def build(self) -> str:
+        return self.value
+
+class HTMLBuilder(Builder):
+    def tag(self, name: str) -> Self:
+        self.value = f"<{name}>{self.value}</{name}>"
+        return self
+
+# Chaining works with correct types
+html = HTMLBuilder().add("Hello").tag("p").build()
+```
+
+## ParamSpec (Python 3.10+)
+
+```python
+from typing import ParamSpec, TypeVar, Callable
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def with_logging(func: Callable[P, R]) -> Callable[P, R]:
+    """Decorator that preserves function signature."""
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        print(f"Calling {func.__name__}")
+        return func(*args, **kwargs)
+    return wrapper
+
+@with_logging
+def greet(name: str, excited: bool = False) -> str:
+    return f"Hello, {name}{'!' if excited else '.'}"
+
+# Signature preserved:
+greet("Alice", excited=True)  # OK
+# greet(123)  # Type error
+```
+
+## TypeVarTuple (Python 3.11+)
+
+```python
+from typing import TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+
+def concat_tuples(
+    a: tuple[*Ts],
+    b: tuple[*Ts]
+) -> tuple[*Ts, *Ts]:
+    return (*a, *b)
+
+# Usage
+result = concat_tuples((1, "a"), (2, "b"))
+# result: tuple[int, str, int, str]
+```
+
+## Covariance and Contravariance
+
+```python
+from typing import TypeVar
+
+# Covariant: Can use subtype
+T_co = TypeVar("T_co", covariant=True)
+
+class Reader(Generic[T_co]):
+    def read(self) -> T_co:
+        ...
+
+# Contravariant: Can use supertype
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class Writer(Generic[T_contra]):
+    def write(self, value: T_contra) -> None:
+        ...
+
+# Invariant (default): Must be exact type
+T = TypeVar("T")  # Invariant
+
+class Container(Generic[T]):
+    def get(self) -> T:
+        ...
+    def set(self, value: T) -> None:
+        ...
+```
+
+## Generic Protocols
+
+```python
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+class Comparable(Protocol[T]):
+    def __lt__(self, other: T) -> bool:
+        ...
+    def __gt__(self, other: T) -> bool:
+        ...
+
+def max_value(a: T, b: T) -> T:
+    return a if a > b else b
+
+# Works with any comparable type
+max_value(1, 2)        # int
+max_value("a", "b")    # str
+```
+
+## Type Aliases
+
+```python
+from typing import TypeAlias
+
+# Simple alias
+Vector: TypeAlias = list[float]
+Matrix: TypeAlias = list[Vector]
+
+# Generic alias
+from typing import TypeVar
+
+T = TypeVar("T")
+Result: TypeAlias = tuple[T, str | None]
+
+def parse(data: str) -> Result[int]:
+    try:
+        return (int(data), None)
+    except ValueError as e:
+        return (0, str(e))
+```
+
+## NewType
+
+```python
+from typing import NewType
+
+# Create distinct types for type safety
+UserId = NewType("UserId", int)
+OrderId = NewType("OrderId", int)
+
+def get_user(user_id: UserId) -> dict:
+    ...
+
+def get_order(order_id: OrderId) -> dict:
+    ...
+
+user_id = UserId(42)
+order_id = OrderId(42)
+
+get_user(user_id)   # OK
+# get_user(order_id)  # Type error!
+# get_user(42)        # Type error!
+```
+
+## Best Practices
+
+1. **Name TypeVars descriptively** - `T`, `K`, `V` for simple cases; `ItemT`, `KeyT` for complex
+2. **Use bounds** - When you need method access on type parameter
+3. **Prefer Protocol** - Over ABC for structural typing
+4. **Use Self** - Instead of quoted class names in return types
+5. **Covariance** - For read-only containers
+6. **Contravariance** - For write-only/function parameter types
+7. **Invariance** - For mutable containers (default, usually correct)

--- a/.agents/skills/python-typing-ops/references/mypy-config.md
+++ b/.agents/skills/python-typing-ops/references/mypy-config.md
@@ -1,0 +1,317 @@
+# mypy and pyright Configuration
+
+Type checker setup for strict, practical type safety.
+
+## mypy Configuration
+
+### pyproject.toml (Recommended)
+
+```toml
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+show_error_codes = true
+show_error_context = true
+
+# Paths
+files = ["src", "tests"]
+exclude = [
+    "migrations/",
+    "venv/",
+    "__pycache__/",
+]
+
+# Per-module overrides
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "requests.*",
+    "boto3.*",
+    "botocore.*",
+]
+ignore_missing_imports = true
+```
+
+### mypy.ini (Alternative)
+
+```ini
+[mypy]
+python_version = 3.11
+strict = True
+warn_return_any = True
+warn_unused_ignores = True
+show_error_codes = True
+
+[mypy-tests.*]
+disallow_untyped_defs = False
+
+[mypy-requests.*]
+ignore_missing_imports = True
+```
+
+## mypy Flags Explained
+
+### Strict Mode Components
+
+```toml
+[tool.mypy]
+# strict = true enables all of these:
+warn_unused_configs = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+no_implicit_reexport = true
+strict_equality = true
+extra_checks = true
+```
+
+### Commonly Adjusted Flags
+
+```toml
+[tool.mypy]
+# Allow untyped defs in some files
+disallow_untyped_defs = true
+
+# But not for tests
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+
+# Ignore third-party stubs
+ignore_missing_imports = true  # Global fallback
+
+# Show where errors occur
+show_error_context = true
+show_column_numbers = true
+show_error_codes = true
+
+# Error output format
+pretty = true
+```
+
+## pyright Configuration
+
+### pyrightconfig.json
+
+```json
+{
+  "include": ["src"],
+  "exclude": ["**/node_modules", "**/__pycache__", "venv"],
+  "pythonVersion": "3.11",
+  "pythonPlatform": "All",
+  "typeCheckingMode": "strict",
+  "reportMissingImports": true,
+  "reportMissingTypeStubs": false,
+  "reportUnusedImport": true,
+  "reportUnusedClass": true,
+  "reportUnusedFunction": true,
+  "reportUnusedVariable": true,
+  "reportDuplicateImport": true,
+  "reportPrivateUsage": true,
+  "reportConstantRedefinition": true,
+  "reportIncompatibleMethodOverride": true,
+  "reportIncompatibleVariableOverride": true,
+  "reportInconsistentConstructor": true,
+  "reportOverlappingOverload": true,
+  "reportUninitializedInstanceVariable": true
+}
+```
+
+### pyproject.toml (pyright)
+
+```toml
+[tool.pyright]
+include = ["src"]
+exclude = ["**/node_modules", "**/__pycache__", "venv"]
+pythonVersion = "3.11"
+typeCheckingMode = "strict"
+reportMissingTypeStubs = false
+```
+
+## Type Checking Modes
+
+### pyright Modes
+
+```json
+{
+  "typeCheckingMode": "off"    // No checking
+  "typeCheckingMode": "basic"  // Basic checks
+  "typeCheckingMode": "standard" // Standard checks
+  "typeCheckingMode": "strict"  // All checks enabled
+}
+```
+
+## Inline Type Ignores
+
+```python
+# Ignore specific error
+result = some_call()  # type: ignore[arg-type]
+
+# Ignore all errors on line
+result = some_call()  # type: ignore
+
+# With mypy error code
+value = data["key"]  # type: ignore[typeddict-item]
+
+# With pyright
+result = func()  # pyright: ignore[reportGeneralTypeIssues]
+```
+
+## Type Stub Files (.pyi)
+
+```python
+# mymodule.pyi - Type stubs for mymodule.py
+
+def process(data: dict[str, int]) -> list[int]: ...
+
+class Handler:
+    def __init__(self, name: str) -> None: ...
+    def handle(self, event: Event) -> bool: ...
+```
+
+### Stub Package Structure
+
+```
+stubs/
+├── mypackage/
+│   ├── __init__.pyi
+│   ├── module.pyi
+│   └── subpackage/
+│       └── __init__.pyi
+```
+
+```toml
+[tool.mypy]
+mypy_path = "stubs"
+```
+
+## CI Integration
+
+### GitHub Actions
+
+```yaml
+name: Type Check
+
+on: [push, pull_request]
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install mypy
+          pip install -e .[dev]
+
+      - name: Run mypy
+        run: mypy src/
+
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -e .[dev]
+
+      - name: Run pyright
+        uses: jakebailey/pyright-action@v2
+```
+
+### Pre-commit Hook
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-requests]
+        args: [--strict]
+```
+
+## Common Type Stubs
+
+```bash
+# Install type stubs
+pip install types-requests
+pip install types-redis
+pip install types-PyYAML
+pip install boto3-stubs[essential]
+
+# Or use mypy to find missing stubs
+mypy --install-types src/
+```
+
+## Gradual Typing Strategy
+
+### Phase 1: Basic
+
+```toml
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_ignores = true
+```
+
+### Phase 2: Stricter
+
+```toml
+[tool.mypy]
+python_version = "3.11"
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+```
+
+### Phase 3: Strict
+
+```toml
+[tool.mypy]
+python_version = "3.11"
+strict = true
+
+# Temporarily ignore problem areas
+[[tool.mypy.overrides]]
+module = "legacy.*"
+ignore_errors = true
+```
+
+## Quick Reference
+
+| mypy Flag | Description |
+|-----------|-------------|
+| `--strict` | Enable all strict checks |
+| `--show-error-codes` | Show error codes for ignores |
+| `--ignore-missing-imports` | Skip untyped libraries |
+| `--python-version 3.11` | Target Python version |
+| `--install-types` | Install missing stubs |
+| `--config-file` | Specify config file |
+
+| pyright Mode | Description |
+|--------------|-------------|
+| `off` | No checking |
+| `basic` | Minimal checks |
+| `standard` | Recommended |
+| `strict` | All checks |

--- a/.agents/skills/python-typing-ops/references/overloads.md
+++ b/.agents/skills/python-typing-ops/references/overloads.md
@@ -1,0 +1,271 @@
+# Function Overloads
+
+Type-safe function signatures with @overload.
+
+## Basic Overloads
+
+```python
+from typing import overload, Literal
+
+# Overload signatures (no implementation)
+@overload
+def process(data: str) -> str: ...
+
+@overload
+def process(data: bytes) -> bytes: ...
+
+@overload
+def process(data: int) -> int: ...
+
+# Actual implementation
+def process(data: str | bytes | int) -> str | bytes | int:
+    if isinstance(data, str):
+        return data.upper()
+    elif isinstance(data, bytes):
+        return data.upper()
+    else:
+        return data * 2
+
+
+# Type checker knows the return type
+result = process("hello")  # str
+result = process(b"hello")  # bytes
+result = process(42)  # int
+```
+
+## Overloads with Literal
+
+```python
+from typing import overload, Literal
+
+@overload
+def fetch(url: str, format: Literal["json"]) -> dict: ...
+
+@overload
+def fetch(url: str, format: Literal["text"]) -> str: ...
+
+@overload
+def fetch(url: str, format: Literal["bytes"]) -> bytes: ...
+
+def fetch(url: str, format: str) -> dict | str | bytes:
+    response = requests.get(url)
+    if format == "json":
+        return response.json()
+    elif format == "text":
+        return response.text
+    else:
+        return response.content
+
+
+# Usage - return type is known
+data = fetch("https://api.example.com", "json")  # dict
+text = fetch("https://api.example.com", "text")  # str
+```
+
+## Overloads with Optional Parameters
+
+```python
+from typing import overload
+
+@overload
+def get_user(user_id: int) -> User: ...
+
+@overload
+def get_user(user_id: int, include_posts: Literal[True]) -> UserWithPosts: ...
+
+@overload
+def get_user(user_id: int, include_posts: Literal[False]) -> User: ...
+
+def get_user(user_id: int, include_posts: bool = False) -> User | UserWithPosts:
+    user = db.get_user(user_id)
+    if include_posts:
+        user.posts = db.get_posts(user_id)
+        return UserWithPosts(**user.__dict__)
+    return user
+
+
+# Type-safe usage
+user = get_user(1)  # User
+user_with_posts = get_user(1, include_posts=True)  # UserWithPosts
+```
+
+## Overloads with None Returns
+
+```python
+from typing import overload
+
+@overload
+def find(items: list[T], predicate: Callable[[T], bool]) -> T | None: ...
+
+@overload
+def find(items: list[T], predicate: Callable[[T], bool], default: T) -> T: ...
+
+def find(
+    items: list[T],
+    predicate: Callable[[T], bool],
+    default: T | None = None
+) -> T | None:
+    for item in items:
+        if predicate(item):
+            return item
+    return default
+
+
+# Without default - might be None
+result = find([1, 2, 3], lambda x: x > 5)  # int | None
+
+# With default - never None
+result = find([1, 2, 3], lambda x: x > 5, default=0)  # int
+```
+
+## Class Method Overloads
+
+```python
+from typing import overload, Self
+from dataclasses import dataclass
+
+@dataclass
+class Point:
+    x: float
+    y: float
+
+    @overload
+    @classmethod
+    def from_tuple(cls, coords: tuple[float, float]) -> Self: ...
+
+    @overload
+    @classmethod
+    def from_tuple(cls, coords: tuple[float, float, float]) -> "Point3D": ...
+
+    @classmethod
+    def from_tuple(cls, coords: tuple[float, ...]) -> "Point | Point3D":
+        if len(coords) == 2:
+            return cls(coords[0], coords[1])
+        elif len(coords) == 3:
+            return Point3D(coords[0], coords[1], coords[2])
+        raise ValueError("Expected 2 or 3 coordinates")
+```
+
+## Overloads with Generics
+
+```python
+from typing import overload, TypeVar, Sequence
+
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
+
+@overload
+def first(items: Sequence[T]) -> T | None: ...
+
+@overload
+def first(items: Sequence[T], default: T) -> T: ...
+
+def first(items: Sequence[T], default: T | None = None) -> T | None:
+    return items[0] if items else default
+
+
+@overload
+def get(d: dict[K, V], key: K) -> V | None: ...
+
+@overload
+def get(d: dict[K, V], key: K, default: V) -> V: ...
+
+def get(d: dict[K, V], key: K, default: V | None = None) -> V | None:
+    return d.get(key, default)
+```
+
+## Async Overloads
+
+```python
+from typing import overload
+
+@overload
+async def fetch_data(url: str, as_json: Literal[True]) -> dict: ...
+
+@overload
+async def fetch_data(url: str, as_json: Literal[False] = False) -> str: ...
+
+async def fetch_data(url: str, as_json: bool = False) -> dict | str:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            if as_json:
+                return await response.json()
+            return await response.text()
+```
+
+## Property Overloads (Getter/Setter)
+
+```python
+from typing import overload
+
+class Temperature:
+    def __init__(self, celsius: float):
+        self._celsius = celsius
+
+    @property
+    def value(self) -> float:
+        return self._celsius
+
+    @overload
+    def convert(self, unit: Literal["C"]) -> float: ...
+
+    @overload
+    def convert(self, unit: Literal["F"]) -> float: ...
+
+    @overload
+    def convert(self, unit: Literal["K"]) -> float: ...
+
+    def convert(self, unit: str) -> float:
+        if unit == "C":
+            return self._celsius
+        elif unit == "F":
+            return self._celsius * 9/5 + 32
+        elif unit == "K":
+            return self._celsius + 273.15
+        raise ValueError(f"Unknown unit: {unit}")
+```
+
+## Common Patterns
+
+```python
+from typing import overload, Literal, TypeVar
+
+T = TypeVar("T")
+
+# Pattern 1: Return type based on flag
+@overload
+def parse(data: str, strict: Literal[True]) -> Result: ...
+@overload
+def parse(data: str, strict: Literal[False] = False) -> Result | None: ...
+
+# Pattern 2: Different return for different input types
+@overload
+def normalize(value: str) -> str: ...
+@overload
+def normalize(value: list[str]) -> list[str]: ...
+@overload
+def normalize(value: dict[str, str]) -> dict[str, str]: ...
+
+# Pattern 3: Optional vs required parameter
+@overload
+def create(name: str) -> Item: ...
+@overload
+def create(name: str, *, template: str) -> Item: ...
+```
+
+## Quick Reference
+
+| Pattern | Use Case |
+|---------|----------|
+| `@overload` | Define signature (no body) |
+| `Literal["value"]` | Specific string/int values |
+| `T \| None` vs `T` | Optional default changes return |
+| Implementation | Must handle all overload cases |
+
+| Rule | Description |
+|------|-------------|
+| No body in overloads | Use `...` (ellipsis) |
+| Implementation last | After all overloads |
+| Cover all cases | Implementation must accept all overload inputs |
+| Static only | Overloads are for type checkers, not runtime |

--- a/.agents/skills/python-typing-ops/references/protocols-patterns.md
+++ b/.agents/skills/python-typing-ops/references/protocols-patterns.md
@@ -1,0 +1,316 @@
+# Protocol Patterns
+
+Structural typing with Protocol for flexible, decoupled code.
+
+## Basic Protocol
+
+```python
+from typing import Protocol
+
+class Drawable(Protocol):
+    def draw(self) -> None:
+        ...
+
+class Circle:
+    def draw(self) -> None:
+        print("Drawing circle")
+
+class Square:
+    def draw(self) -> None:
+        print("Drawing square")
+
+def render(shape: Drawable) -> None:
+    shape.draw()
+
+# Both work - no inheritance needed
+render(Circle())
+render(Square())
+```
+
+## Protocol with Attributes
+
+```python
+from typing import Protocol
+
+class Named(Protocol):
+    name: str
+
+class HasId(Protocol):
+    id: int
+    name: str
+
+class User:
+    def __init__(self, id: int, name: str):
+        self.id = id
+        self.name = name
+
+def greet(entity: Named) -> str:
+    return f"Hello, {entity.name}"
+
+# Works with any object having 'name' attribute
+greet(User(1, "Alice"))
+```
+
+## Protocol with Methods
+
+```python
+from typing import Protocol
+
+class Closeable(Protocol):
+    def close(self) -> None:
+        ...
+
+class Flushable(Protocol):
+    def flush(self) -> None:
+        ...
+
+class CloseableAndFlushable(Closeable, Flushable, Protocol):
+    """Combined protocol."""
+    pass
+
+def cleanup(resource: CloseableAndFlushable) -> None:
+    resource.flush()
+    resource.close()
+```
+
+## Callable Protocol
+
+```python
+from typing import Protocol
+
+class Comparator(Protocol):
+    def __call__(self, a: int, b: int) -> int:
+        """Return negative, zero, or positive."""
+        ...
+
+def sort_with(items: list[int], cmp: Comparator) -> list[int]:
+    return sorted(items, key=lambda x: cmp(x, 0))
+
+# Lambda works
+sort_with([3, 1, 2], lambda a, b: a - b)
+
+# Function works
+def compare(a: int, b: int) -> int:
+    return a - b
+
+sort_with([3, 1, 2], compare)
+```
+
+## Generic Protocol
+
+```python
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+class Container(Protocol[T]):
+    def get(self) -> T:
+        ...
+
+    def set(self, value: T) -> None:
+        ...
+
+class Box:
+    def __init__(self, value: int):
+        self._value = value
+
+    def get(self) -> int:
+        return self._value
+
+    def set(self, value: int) -> None:
+        self._value = value
+
+def process(container: Container[int]) -> int:
+    value = container.get()
+    container.set(value * 2)
+    return container.get()
+
+process(Box(5))  # Returns 10
+```
+
+## Runtime Checkable Protocol
+
+```python
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class Sized(Protocol):
+    def __len__(self) -> int:
+        ...
+
+# Now isinstance() works
+def process(obj: object) -> int:
+    if isinstance(obj, Sized):
+        return len(obj)
+    return 0
+
+process([1, 2, 3])  # 3
+process("hello")     # 5
+process(42)          # 0
+```
+
+## Protocol vs ABC
+
+```python
+from abc import ABC, abstractmethod
+from typing import Protocol
+
+# ABC - Requires explicit inheritance
+class AbstractReader(ABC):
+    @abstractmethod
+    def read(self) -> str:
+        pass
+
+class FileReader(AbstractReader):  # Must inherit
+    def read(self) -> str:
+        return "content"
+
+# Protocol - Structural (duck typing)
+class ReaderProtocol(Protocol):
+    def read(self) -> str:
+        ...
+
+class AnyReader:  # No inheritance needed
+    def read(self) -> str:
+        return "content"
+
+def process(reader: ReaderProtocol) -> str:
+    return reader.read()
+
+process(AnyReader())  # Works!
+process(FileReader())  # Also works!
+```
+
+## Common Protocols
+
+### Supports Protocols
+
+```python
+from typing import SupportsInt, SupportsFloat, SupportsBytes, SupportsAbs
+
+def to_int(value: SupportsInt) -> int:
+    return int(value)
+
+to_int(3.14)   # OK - float supports __int__
+to_int("42")   # Error - str doesn't support __int__
+```
+
+### Iterator Protocol
+
+```python
+from typing import Protocol, TypeVar
+
+T = TypeVar("T", covariant=True)
+
+class Iterator(Protocol[T]):
+    def __next__(self) -> T:
+        ...
+
+class Iterable(Protocol[T]):
+    def __iter__(self) -> Iterator[T]:
+        ...
+```
+
+### Context Manager Protocol
+
+```python
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+class ContextManager(Protocol[T]):
+    def __enter__(self) -> T:
+        ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object | None,
+    ) -> bool | None:
+        ...
+```
+
+## Real-World Patterns
+
+### Repository Pattern
+
+```python
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+class Repository(Protocol[T]):
+    def get(self, id: int) -> T | None:
+        ...
+
+    def save(self, entity: T) -> None:
+        ...
+
+    def delete(self, id: int) -> bool:
+        ...
+
+class User:
+    id: int
+    name: str
+
+class InMemoryUserRepo:
+    def __init__(self):
+        self._data: dict[int, User] = {}
+
+    def get(self, id: int) -> User | None:
+        return self._data.get(id)
+
+    def save(self, entity: User) -> None:
+        self._data[entity.id] = entity
+
+    def delete(self, id: int) -> bool:
+        return self._data.pop(id, None) is not None
+
+def process_users(repo: Repository[User]) -> None:
+    user = repo.get(1)
+    if user:
+        repo.delete(user.id)
+```
+
+### Event Handler
+
+```python
+from typing import Protocol
+
+class Event:
+    pass
+
+class UserCreated(Event):
+    def __init__(self, user_id: int):
+        self.user_id = user_id
+
+class EventHandler(Protocol):
+    def can_handle(self, event: Event) -> bool:
+        ...
+
+    def handle(self, event: Event) -> None:
+        ...
+
+class UserCreatedHandler:
+    def can_handle(self, event: Event) -> bool:
+        return isinstance(event, UserCreated)
+
+    def handle(self, event: Event) -> None:
+        if isinstance(event, UserCreated):
+            print(f"User {event.user_id} created")
+
+def dispatch(event: Event, handlers: list[EventHandler]) -> None:
+    for handler in handlers:
+        if handler.can_handle(event):
+            handler.handle(event)
+```
+
+## Best Practices
+
+1. **Prefer Protocol over ABC** - For external interfaces
+2. **Use @runtime_checkable sparingly** - Has performance cost
+3. **Keep protocols minimal** - Single responsibility
+4. **Document expected behavior** - Protocols only define shape, not behavior
+5. **Combine protocols** - For complex requirements
+6. **Use Generic protocols** - For type-safe containers

--- a/.agents/skills/python-typing-ops/references/runtime-validation.md
+++ b/.agents/skills/python-typing-ops/references/runtime-validation.md
@@ -1,0 +1,297 @@
+# Runtime Type Validation
+
+Enforce type hints at runtime with Pydantic, typeguard, and beartype.
+
+## Pydantic v2 Validation
+
+```python
+from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import EmailStr, HttpUrl, PositiveInt
+from datetime import datetime
+from typing import Self
+
+class User(BaseModel):
+    """Model with automatic validation."""
+    id: PositiveInt
+    name: str = Field(..., min_length=1, max_length=100)
+    email: EmailStr
+    website: HttpUrl | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    @field_validator("name")
+    @classmethod
+    def name_must_be_title_case(cls, v: str) -> str:
+        return v.title()
+
+    @model_validator(mode="after")
+    def check_consistency(self) -> Self:
+        # Cross-field validation
+        return self
+
+
+# Usage - raises ValidationError on invalid data
+user = User(id=1, name="john doe", email="john@example.com")
+print(user.name)  # "John Doe" (transformed)
+
+# From dict
+user = User.model_validate({"id": 1, "name": "jane", "email": "jane@example.com"})
+
+# Validation error
+try:
+    User(id=-1, name="", email="invalid")
+except ValidationError as e:
+    print(e.errors())
+```
+
+## Pydantic for Function Arguments
+
+```python
+from pydantic import validate_call, Field
+from typing import Annotated
+
+@validate_call
+def greet(
+    name: Annotated[str, Field(min_length=1)],
+    count: Annotated[int, Field(ge=1, le=10)] = 1,
+) -> str:
+    return f"Hello, {name}!" * count
+
+
+# Valid
+greet("World")  # OK
+greet("World", count=3)  # OK
+
+# Invalid - raises ValidationError
+greet("")  # Error: min_length
+greet("World", count=100)  # Error: le
+```
+
+## typeguard (Runtime Type Checking)
+
+```python
+from typeguard import typechecked, check_type
+from typing import TypeVar, Generic
+
+# Decorator for function checking
+@typechecked
+def process(items: list[int], multiplier: float) -> list[float]:
+    return [item * multiplier for item in items]
+
+# Valid
+process([1, 2, 3], 1.5)  # OK
+
+# Invalid - raises TypeCheckError at runtime
+process(["a", "b"], 1.5)  # Error: list[int] expected
+
+
+# Check types manually
+from typeguard import check_type
+
+value = [1, 2, 3]
+check_type(value, list[int])  # OK
+
+value = [1, "two", 3]
+check_type(value, list[int])  # TypeCheckError
+
+
+# Class checking
+@typechecked
+class DataProcessor(Generic[T]):
+    def __init__(self, data: list[T]):
+        self.data = data
+
+    def process(self) -> T:
+        return self.data[0]
+```
+
+## beartype (Fast Runtime Checking)
+
+```python
+from beartype import beartype
+from beartype.typing import List, Optional
+
+# ~200x faster than typeguard
+@beartype
+def fast_process(items: List[int], factor: float) -> List[float]:
+    return [i * factor for i in items]
+
+
+# With optional
+@beartype
+def find_user(user_id: int) -> Optional[dict]:
+    return None
+
+
+# Class decorator
+@beartype
+class FastProcessor:
+    def __init__(self, data: list[int]):
+        self.data = data
+
+    def sum(self) -> int:
+        return sum(self.data)
+```
+
+## TypedDict Runtime Validation
+
+```python
+from typing import TypedDict, Required, NotRequired
+from pydantic import TypeAdapter
+
+class UserDict(TypedDict):
+    id: Required[int]
+    name: Required[str]
+    email: NotRequired[str]
+
+
+# Using Pydantic to validate TypedDict
+adapter = TypeAdapter(UserDict)
+
+# Valid
+user = adapter.validate_python({"id": 1, "name": "John"})
+
+# Invalid - raises ValidationError
+adapter.validate_python({"id": "not-int", "name": "John"})
+
+
+# JSON parsing with validation
+user = adapter.validate_json('{"id": 1, "name": "John"}')
+```
+
+## dataclass Validation with Pydantic
+
+```python
+from dataclasses import dataclass
+from pydantic import TypeAdapter
+from typing import Annotated
+from annotated_types import Gt, Lt
+
+@dataclass
+class Point:
+    x: Annotated[float, Gt(-100), Lt(100)]
+    y: Annotated[float, Gt(-100), Lt(100)]
+
+
+# Create validator
+validator = TypeAdapter(Point)
+
+# Validate
+point = validator.validate_python({"x": 10.5, "y": 20.3})
+
+# Or with init
+point = validator.validate_python(Point(x=10.5, y=20.3))
+```
+
+## Custom Validators
+
+```python
+from pydantic import BaseModel, field_validator, ValidationInfo
+from pydantic_core import PydanticCustomError
+import re
+
+class Account(BaseModel):
+    username: str
+    password: str
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v: str) -> str:
+        if not re.match(r"^[a-z][a-z0-9_]{2,19}$", v):
+            raise PydanticCustomError(
+                "invalid_username",
+                "Username must be 3-20 chars, start with letter, contain only a-z, 0-9, _"
+            )
+        return v
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str, info: ValidationInfo) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        if info.data.get("username") and info.data["username"] in v:
+            raise ValueError("Password cannot contain username")
+        return v
+```
+
+## Constrained Types
+
+```python
+from pydantic import (
+    BaseModel,
+    PositiveInt,
+    NegativeFloat,
+    conint,
+    constr,
+    conlist,
+)
+
+class Order(BaseModel):
+    quantity: PositiveInt  # > 0
+    discount: NegativeFloat | None = None  # < 0
+
+    # Custom constraints
+    product_code: constr(pattern=r"^[A-Z]{3}-\d{4}$")
+    priority: conint(ge=1, le=5)
+    tags: conlist(str, min_length=1, max_length=10)
+
+
+# Usage
+order = Order(
+    quantity=5,
+    product_code="ABC-1234",
+    priority=3,
+    tags=["urgent"]
+)
+```
+
+## When to Use Each
+
+| Tool | Speed | Strictness | Use Case |
+|------|-------|------------|----------|
+| Pydantic | Medium | High | API validation, config |
+| typeguard | Slow | Very high | Testing, debugging |
+| beartype | Fast | Medium | Production code |
+
+```python
+# Development: Use typeguard for strictest checking
+from typeguard import typechecked
+
+@typechecked
+def dev_function(x: list[int]) -> int:
+    return sum(x)
+
+
+# Production: Use beartype for minimal overhead
+from beartype import beartype
+
+@beartype
+def prod_function(x: list[int]) -> int:
+    return sum(x)
+
+
+# API boundaries: Use Pydantic for validation + serialization
+from pydantic import BaseModel
+
+class Request(BaseModel):
+    items: list[int]
+
+def api_function(request: Request) -> int:
+    return sum(request.items)
+```
+
+## Quick Reference
+
+| Library | Decorator | Check |
+|---------|-----------|-------|
+| Pydantic | `@validate_call` | `Model.model_validate()` |
+| typeguard | `@typechecked` | `check_type(val, Type)` |
+| beartype | `@beartype` | Automatic on call |
+
+| Pydantic Type | Constraint |
+|---------------|------------|
+| `PositiveInt` | `> 0` |
+| `NegativeInt` | `< 0` |
+| `conint(ge=0, le=100)` | `0 <= x <= 100` |
+| `constr(min_length=1)` | Non-empty string |
+| `EmailStr` | Valid email |
+| `HttpUrl` | Valid URL |

--- a/.agents/skills/python-typing-ops/references/type-narrowing.md
+++ b/.agents/skills/python-typing-ops/references/type-narrowing.md
@@ -1,0 +1,271 @@
+# Type Narrowing
+
+Techniques for narrowing types in conditional branches.
+
+## isinstance Narrowing
+
+```python
+def process(value: str | int | list[str]) -> str:
+    if isinstance(value, str):
+        # value is str here
+        return value.upper()
+    elif isinstance(value, int):
+        # value is int here
+        return str(value * 2)
+    else:
+        # value is list[str] here
+        return ", ".join(value)
+```
+
+## None Checks
+
+```python
+def greet(name: str | None) -> str:
+    if name is None:
+        return "Hello, stranger"
+    # name is str here (not None)
+    return f"Hello, {name}"
+
+# Also works with truthiness
+def greet_truthy(name: str | None) -> str:
+    if name:
+        # name is str here
+        return f"Hello, {name}"
+    return "Hello, stranger"
+```
+
+## Assertion Narrowing
+
+```python
+def process(data: dict | None) -> str:
+    assert data is not None
+    # data is dict here
+    return str(data.get("key"))
+
+def validate(value: int | str) -> int:
+    assert isinstance(value, int), "Must be int"
+    # value is int here
+    return value * 2
+```
+
+## Type Guards
+
+```python
+from typing import TypeGuard
+
+def is_string_list(val: list[object]) -> TypeGuard[list[str]]:
+    """Check if all elements are strings."""
+    return all(isinstance(x, str) for x in val)
+
+def process(items: list[object]) -> str:
+    if is_string_list(items):
+        # items is list[str] here
+        return ", ".join(items)
+    return "Not all strings"
+
+# With TypeVar
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def is_not_none(val: T | None) -> TypeGuard[T]:
+    return val is not None
+
+def process_optional(value: str | None) -> str:
+    if is_not_none(value):
+        # value is str here
+        return value.upper()
+    return "default"
+```
+
+## TypeIs (Python 3.13+)
+
+```python
+from typing import TypeIs
+
+# TypeIs narrows more aggressively than TypeGuard
+def is_str(val: object) -> TypeIs[str]:
+    return isinstance(val, str)
+
+def process(value: object) -> str:
+    if is_str(value):
+        # value is str here
+        return value.upper()
+    return "not a string"
+```
+
+## Discriminated Unions
+
+```python
+from typing import Literal, TypedDict
+
+class SuccessResult(TypedDict):
+    status: Literal["success"]
+    data: dict
+
+class ErrorResult(TypedDict):
+    status: Literal["error"]
+    message: str
+
+Result = SuccessResult | ErrorResult
+
+def handle_result(result: Result) -> str:
+    if result["status"] == "success":
+        # result is SuccessResult
+        return str(result["data"])
+    else:
+        # result is ErrorResult
+        return f"Error: {result['message']}"
+```
+
+## Match Statement (Python 3.10+)
+
+```python
+def describe(value: int | str | list[int]) -> str:
+    match value:
+        case int(n):
+            return f"Integer: {n}"
+        case str(s):
+            return f"String: {s}"
+        case [first, *rest]:
+            return f"List starting with {first}"
+        case _:
+            return "Unknown"
+```
+
+## hasattr Narrowing
+
+```python
+from typing import Protocol
+
+class HasName(Protocol):
+    name: str
+
+def greet(obj: object) -> str:
+    if hasattr(obj, "name") and isinstance(obj.name, str):
+        # Type checkers may not narrow here
+        # Use Protocol + isinstance instead
+        return f"Hello, {obj.name}"
+    return "Hello"
+```
+
+## Callable Narrowing
+
+```python
+from collections.abc import Callable
+
+def execute(func_or_value: Callable[[], int] | int) -> int:
+    if callable(func_or_value):
+        # func_or_value is Callable[[], int]
+        return func_or_value()
+    else:
+        # func_or_value is int
+        return func_or_value
+```
+
+## Exhaustiveness Checking
+
+```python
+from typing import Literal, Never
+
+def assert_never(value: Never) -> Never:
+    raise AssertionError(f"Unexpected value: {value}")
+
+Status = Literal["pending", "active", "closed"]
+
+def handle_status(status: Status) -> str:
+    if status == "pending":
+        return "Waiting..."
+    elif status == "active":
+        return "In progress"
+    elif status == "closed":
+        return "Done"
+    else:
+        # If we add a new status, type checker will error here
+        assert_never(status)
+```
+
+## Narrowing in Loops
+
+```python
+from typing import TypeGuard
+
+def is_valid(item: str | None) -> TypeGuard[str]:
+    return item is not None
+
+def process_items(items: list[str | None]) -> list[str]:
+    result: list[str] = []
+    for item in items:
+        if is_valid(item):
+            # item is str here
+            result.append(item.upper())
+    return result
+
+# Or use filter with type guard
+def process_items_functional(items: list[str | None]) -> list[str]:
+    valid_items = filter(is_valid, items)
+    return [item.upper() for item in valid_items]
+```
+
+## Class Type Narrowing
+
+```python
+class Animal:
+    pass
+
+class Dog(Animal):
+    def bark(self) -> str:
+        return "Woof!"
+
+class Cat(Animal):
+    def meow(self) -> str:
+        return "Meow!"
+
+def make_sound(animal: Animal) -> str:
+    if isinstance(animal, Dog):
+        return animal.bark()  # animal is Dog
+    elif isinstance(animal, Cat):
+        return animal.meow()  # animal is Cat
+    return "..."
+```
+
+## Common Patterns
+
+### Optional Unwrapping
+
+```python
+def unwrap_or_default(value: T | None, default: T) -> T:
+    if value is not None:
+        return value
+    return default
+
+# With early return
+def process(data: dict | None) -> dict:
+    if data is None:
+        return {}
+    # data is dict for rest of function
+    return {k: v.upper() for k, v in data.items()}
+```
+
+### Safe Dictionary Access
+
+```python
+def get_nested(data: dict, *keys: str) -> object | None:
+    result: object = data
+    for key in keys:
+        if not isinstance(result, dict):
+            return None
+        result = result.get(key)
+        if result is None:
+            return None
+    return result
+```
+
+## Best Practices
+
+1. **Prefer isinstance** - Most reliable for type narrowing
+2. **Use TypeGuard** - For complex conditions
+3. **Check None explicitly** - `is None` or `is not None`
+4. **Use exhaustiveness checks** - Catch missing cases
+5. **Avoid hasattr** - Type checkers struggle with it
+6. **Match statements** - Clean pattern matching (3.10+)

--- a/.agents/skills/python-typing-ops/scripts/check-types.sh
+++ b/.agents/skills/python-typing-ops/scripts/check-types.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Run type checkers with common options
+# Usage: ./check-types.sh [--mypy|--pyright|--both] [--strict] [path]
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Defaults
+CHECKER="both"
+STRICT=""
+TARGET="src"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --mypy)
+            CHECKER="mypy"
+            shift
+            ;;
+        --pyright)
+            CHECKER="pyright"
+            shift
+            ;;
+        --both)
+            CHECKER="both"
+            shift
+            ;;
+        --strict)
+            STRICT="--strict"
+            shift
+            ;;
+        *)
+            TARGET="$1"
+            shift
+            ;;
+    esac
+done
+
+# Check if target exists
+if [[ ! -e "$TARGET" ]]; then
+    echo -e "${RED}Target not found: $TARGET${NC}"
+    exit 1
+fi
+
+run_mypy() {
+    echo -e "${BLUE}=== Running mypy ===${NC}"
+
+    if ! command -v mypy &> /dev/null; then
+        echo -e "${YELLOW}mypy not found. Install with: pip install mypy${NC}"
+        return 1
+    fi
+
+    MYPY_ARGS="--show-error-codes --show-error-context --pretty"
+    if [[ -n "$STRICT" ]]; then
+        MYPY_ARGS="$MYPY_ARGS --strict"
+    fi
+
+    echo "mypy $MYPY_ARGS $TARGET"
+    echo ""
+
+    if mypy $MYPY_ARGS "$TARGET"; then
+        echo -e "${GREEN}✓ mypy passed${NC}"
+        return 0
+    else
+        echo -e "${RED}✗ mypy found errors${NC}"
+        return 1
+    fi
+}
+
+run_pyright() {
+    echo -e "${BLUE}=== Running pyright ===${NC}"
+
+    if ! command -v pyright &> /dev/null; then
+        echo -e "${YELLOW}pyright not found. Install with: pip install pyright${NC}"
+        return 1
+    fi
+
+    PYRIGHT_ARGS=""
+    if [[ -n "$STRICT" ]]; then
+        # Create temporary config for strict mode
+        TEMP_CONFIG=$(mktemp)
+        cat > "$TEMP_CONFIG" << EOF
+{
+  "typeCheckingMode": "strict"
+}
+EOF
+        PYRIGHT_ARGS="--project $TEMP_CONFIG"
+    fi
+
+    echo "pyright $PYRIGHT_ARGS $TARGET"
+    echo ""
+
+    if pyright $PYRIGHT_ARGS "$TARGET"; then
+        echo -e "${GREEN}✓ pyright passed${NC}"
+        [[ -n "$STRICT" ]] && rm -f "$TEMP_CONFIG"
+        return 0
+    else
+        echo -e "${RED}✗ pyright found errors${NC}"
+        [[ -n "$STRICT" ]] && rm -f "$TEMP_CONFIG"
+        return 1
+    fi
+}
+
+# Run checkers
+MYPY_STATUS=0
+PYRIGHT_STATUS=0
+
+case $CHECKER in
+    mypy)
+        run_mypy || MYPY_STATUS=$?
+        ;;
+    pyright)
+        run_pyright || PYRIGHT_STATUS=$?
+        ;;
+    both)
+        run_mypy || MYPY_STATUS=$?
+        echo ""
+        run_pyright || PYRIGHT_STATUS=$?
+        ;;
+esac
+
+# Summary
+echo ""
+echo -e "${BLUE}=== Summary ===${NC}"
+
+if [[ "$CHECKER" == "both" ]] || [[ "$CHECKER" == "mypy" ]]; then
+    if [[ $MYPY_STATUS -eq 0 ]]; then
+        echo -e "mypy:    ${GREEN}✓ passed${NC}"
+    else
+        echo -e "mypy:    ${RED}✗ failed${NC}"
+    fi
+fi
+
+if [[ "$CHECKER" == "both" ]] || [[ "$CHECKER" == "pyright" ]]; then
+    if [[ $PYRIGHT_STATUS -eq 0 ]]; then
+        echo -e "pyright: ${GREEN}✓ passed${NC}"
+    else
+        echo -e "pyright: ${RED}✗ failed${NC}"
+    fi
+fi
+
+# Exit with error if any checker failed
+if [[ $MYPY_STATUS -ne 0 ]] || [[ $PYRIGHT_STATUS -ne 0 ]]; then
+    exit 1
+fi

--- a/.agents/skills/ruff-linting/SKILL.md
+++ b/.agents/skills/ruff-linting/SKILL.md
@@ -1,0 +1,486 @@
+---
+model: haiku
+created: 2025-12-16
+modified: 2025-12-16
+reviewed: 2025-12-16
+name: ruff-linting
+description: Python code quality with ruff linter. Fast linting, rule selection, auto-fixing, and configuration. Use when checking Python code quality, enforcing standards, or finding bugs.
+user-invocable: false
+allowed-tools: Bash(ruff *), Bash(python *), Bash(uv *), Read, Edit, Write, Grep, Glob
+---
+
+# ruff Linting
+
+Expert knowledge for using `ruff check` as an extremely fast Python linter with comprehensive rule support and automatic fixing.
+
+## Core Expertise
+
+**ruff Advantages**
+- Extremely fast (10-100x faster than Flake8)
+- Written in Rust for performance
+- Replaces multiple tools (Flake8, pylint, isort, pyupgrade, etc.)
+- Auto-fix capabilities for many rules
+- Compatible with existing configurations
+- Over 800 built-in rules
+
+## Basic Usage
+
+### Simple Linting
+```bash
+# Lint current directory
+ruff check
+
+# Lint specific files or directories
+ruff check path/to/file.py
+ruff check src/ tests/
+
+# IMPORTANT: Pass directory as parameter to stay in repo root
+# ✅ Good
+ruff check services/orchestrator
+
+# ❌ Bad
+cd services/orchestrator && ruff check
+```
+
+### Auto-Fixing
+```bash
+# Show what would be fixed (diff preview)
+ruff check --diff
+
+# Apply safe automatic fixes
+ruff check --fix
+
+# Fix specific files
+ruff check --fix src/main.py
+
+# Fix with preview (see changes before applying)
+ruff check --diff services/orchestrator
+ruff check --fix services/orchestrator
+```
+
+### Output Formats
+```bash
+# Default output
+ruff check
+
+# Show statistics
+ruff check --statistics
+
+# JSON output for tooling
+ruff check --output-format json
+
+# GitHub Actions annotations
+ruff check --output-format github
+
+# GitLab Code Quality report
+ruff check --output-format gitlab
+
+# Concise output
+ruff check --output-format concise
+```
+
+## Rule Selection
+
+### Common Rule Codes
+
+| Code | Description | Example Rules |
+|------|-------------|---------------|
+| `E` | pycodestyle errors | E501 (line too long) |
+| `F` | Pyflakes | F401 (unused import) |
+| `W` | pycodestyle warnings | W605 (invalid escape) |
+| `B` | flake8-bugbear | B006 (mutable default) |
+| `I` | isort | I001 (unsorted imports) |
+| `UP` | pyupgrade | UP006 (deprecated types) |
+| `SIM` | flake8-simplify | SIM102 (nested if) |
+| `D` | pydocstyle | D100 (missing docstring) |
+| `N` | pep8-naming | N806 (variable naming) |
+| `S` | flake8-bandit (security) | S101 (assert usage) |
+| `C4` | flake8-comprehensions | C400 (unnecessary generator) |
+
+### Selecting Rules
+```bash
+# Select specific rules at runtime
+ruff check --select E,F,B,I
+
+# Extend default selection
+ruff check --extend-select UP,SIM
+
+# Ignore specific rules
+ruff check --ignore E501,E402
+
+# Show which rules would apply
+ruff rule --all
+
+# Explain a specific rule
+ruff rule F401
+```
+
+### Rule Queries
+```bash
+# List all available rules
+ruff rule --all
+
+# Search for rules by pattern
+ruff rule --all | grep "import"
+
+# Get detailed rule explanation
+ruff rule F401
+# Output: unused-import (F401)
+#   Derived from the Pyflakes linter.
+#   Checks for unused imports.
+
+# List all linters
+ruff linter
+
+# JSON output for automation
+ruff rule F401 --output-format json
+```
+
+## Configuration
+
+### pyproject.toml
+```toml
+[tool.ruff]
+# Line length limit (same as Black)
+line-length = 88
+
+# Target Python version
+target-version = "py311"
+
+# Exclude directories
+exclude = [
+    ".git",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+]
+
+[tool.ruff.lint]
+# Enable specific rule sets
+select = [
+    "E",   # pycodestyle errors
+    "F",   # Pyflakes
+    "B",   # flake8-bugbear
+    "I",   # isort
+    "UP",  # pyupgrade
+    "SIM", # flake8-simplify
+]
+
+# Disable specific rules
+ignore = [
+    "E501",  # Line too long (handled by formatter)
+    "B008",  # Function calls in argument defaults
+]
+
+# Allow automatic fixes
+fixable = ["ALL"]
+unfixable = ["B"]  # Don't auto-fix bugbear rules
+
+# Per-file ignores
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "E402"]
+"tests/**/*.py" = ["S101"]  # Allow assert in tests
+```
+
+### ruff.toml (standalone)
+```toml
+# Same options as pyproject.toml but without [tool.ruff] prefix
+line-length = 100
+target-version = "py39"
+
+[lint]
+select = ["E", "F", "B"]
+ignore = ["E501"]
+
+[lint.isort]
+known-first-party = ["myapp"]
+force-single-line = true
+```
+
+## Advanced Usage
+
+### Per-File Configuration
+```bash
+# Override settings for specific paths
+ruff check --config path/to/ruff.toml
+
+# Use inline configuration
+ruff check --select E,F,B --ignore E501
+```
+
+### Targeting Specific Issues
+```bash
+# Check only specific rule codes
+ruff check --select F401,F841  # Only unused imports/variables
+
+# Security-focused check
+ruff check --select S  # All bandit rules
+
+# Import organization only
+ruff check --select I --fix
+
+# Docstring checks
+ruff check --select D
+```
+
+### Integration Patterns
+```bash
+# Check only changed files (git)
+git diff --name-only --diff-filter=d | grep '\.py$' | xargs ruff check
+
+# Check files modified in branch
+git diff --name-only main...HEAD | grep '\.py$' | xargs ruff check
+
+# Parallel checking of multiple directories
+ruff check src/ &
+ruff check tests/ &
+wait
+
+# Combine with other tools
+ruff check && pytest && ty check
+```
+
+## CI/CD Integration
+
+### Pre-commit Hook
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.0
+    hooks:
+      # Linter with auto-fix
+      - id: ruff-check
+        args: [--fix]
+
+      # Advanced configuration
+      - id: ruff-check
+        name: Ruff linter
+        args:
+          - --fix
+          - --config=pyproject.toml
+          - --select=E,F,B,I
+        types_or: [python, pyi, jupyter]
+```
+
+### GitHub Actions
+```yaml
+# .github/workflows/lint.yml
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: 'check --output-format github'
+          changed-files: 'true'
+
+      # Or using pip
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run linter
+        run: ruff check --output-format github
+```
+
+### GitLab CI
+```yaml
+# .gitlab-ci.yml
+Ruff Check:
+  stage: build
+  image: ghcr.io/astral-sh/ruff:0.14.0-alpine
+  script:
+    - ruff check --output-format=gitlab > code-quality-report.json
+  artifacts:
+    reports:
+      codequality: code-quality-report.json
+```
+
+## Common Patterns
+
+### Finding Specific Issues
+```bash
+# Find unused imports
+ruff check --select F401
+
+# Find mutable default arguments
+ruff check --select B006
+
+# Find deprecated type usage
+ruff check --select UP006
+
+# Security issues
+ruff check --select S
+
+# Code complexity
+ruff check --select C901
+
+# Find all TODOs
+ruff check --select FIX  # flake8-fixme
+```
+
+### Gradual Adoption
+```bash
+# Start with minimal rules
+ruff check --select E,F
+
+# Add bugbear
+ruff check --select E,F,B
+
+# Add import sorting
+ruff check --select E,F,B,I --fix
+
+# Add pyupgrade
+ruff check --select E,F,B,I,UP --fix
+
+# Generate baseline configuration
+ruff check --select ALL --ignore <violations> > ruff-baseline.toml
+```
+
+### Refactoring Support
+```bash
+# Auto-fix all safe violations
+ruff check --fix
+
+# Preview changes before fixing
+ruff check --diff | less
+
+# Fix only imports
+ruff check --select I --fix
+
+# Modernize code
+ruff check --select UP --fix
+
+# Simplify comprehensions
+ruff check --select C4,SIM --fix
+```
+
+## Plugin Configuration
+
+### isort (Import Sorting)
+```toml
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["myapp"]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+```
+
+### flake8-quotes
+```toml
+[tool.ruff.lint.flake8-quotes]
+docstring-quotes = "double"
+inline-quotes = "single"
+multiline-quotes = "double"
+```
+
+### pydocstyle
+```toml
+[tool.ruff.lint.pydocstyle]
+convention = "google"  # or "numpy", "pep257"
+```
+
+### pylint
+```toml
+[tool.ruff.lint.pylint]
+max-args = 10
+max-branches = 15
+max-returns = 8
+max-statements = 60
+```
+
+## Best Practices
+
+**When to Use ruff check**
+- Code quality enforcement
+- Pre-commit validation
+- CI/CD pipelines
+- Refactoring assistance
+- Security scanning
+- Import organization
+
+**Critical: Directory Parameters**
+- ✅ **Always** pass directory as parameter: `ruff check services/orchestrator`
+- ❌ **Never** use cd: `cd services/orchestrator && ruff check`
+- Reason: Parallel execution, clearer output, tool compatibility
+
+**Rule Selection Strategy**
+1. Start minimal: `select = ["E", "F"]` (errors + pyflakes)
+2. Add bugbear: `select = ["E", "F", "B"]`
+3. Add imports: `select = ["E", "F", "B", "I"]`
+4. Add pyupgrade: `select = ["E", "F", "B", "I", "UP"]`
+5. Consider security: `select = ["E", "F", "B", "I", "UP", "S"]`
+
+**Fixable vs Unfixable**
+- Mark uncertain rules as `unfixable` to review manually
+- Common unfixables: `B` (bugbear), `F` (pyflakes F401)
+- Let ruff fix safe rules: `I` (isort), `UP` (pyupgrade)
+
+**Common Mistakes to Avoid**
+- Using `cd` instead of passing directory parameter
+- Enabling ALL rules immediately (use gradual adoption)
+- Not using `--diff` before `--fix`
+- Ignoring rule explanations (`ruff rule <code>`)
+- Not configuring per-file ignores for special cases
+
+## Quick Reference
+
+### Essential Commands
+
+```bash
+# Basic operations
+ruff check                          # Lint current directory
+ruff check path/to/dir              # Lint specific directory
+ruff check --diff                   # Show fix preview
+ruff check --fix                    # Apply fixes
+
+# Rule management
+ruff rule --all                     # List all rules
+ruff rule F401                      # Explain rule F401
+ruff linter                         # List all linters
+
+# Output formats
+ruff check --statistics             # Show violation counts
+ruff check --output-format json     # JSON output
+ruff check --output-format github   # GitHub Actions format
+
+# Selection
+ruff check --select E,F,B          # Select rules
+ruff check --ignore E501           # Ignore rules
+ruff check --extend-select UP      # Extend selection
+```
+
+### Configuration Hierarchy
+
+1. Command-line arguments (highest priority)
+2. `ruff.toml` in current directory
+3. `pyproject.toml` in current directory
+4. Parent directory configs (recursive)
+5. User config: `~/.config/ruff/ruff.toml`
+
+### Common Rule Combinations
+
+```bash
+# Minimal safety
+ruff check --select E,F
+
+# Good default
+ruff check --select E,F,B,I
+
+# Comprehensive
+ruff check --select E,F,B,I,UP,SIM
+
+# Security-focused
+ruff check --select E,F,B,S
+
+# Docstring enforcement
+ruff check --select D --config '[lint.pydocstyle]\nconvention = "google"'
+```
+
+This makes ruff check the preferred tool for fast, comprehensive Python code linting.

--- a/.agents/skills/skill-creator/LICENSE.txt
+++ b/.agents/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+---
+
+# Skill Creator
+
+A skill for creating new skills and iteratively improving them.
+
+At a high level, the process of creating a skill goes like this:
+
+- Decide what you want the skill to do and roughly how it should do it
+- Write a draft of the skill
+- Create a few test prompts and run claude-with-access-to-the-skill on them
+- Help the user evaluate the results both qualitatively and quantitatively
+  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
+  - Use the `eval-viewer/generate_review.py` script to show the user the results for them to look at, and also let them look at the quantitative metrics
+- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
+- Repeat until you're satisfied
+- Expand the test set and try again at larger scale
+
+Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
+
+On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
+
+Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+
+Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
+
+Cool? Cool.
+
+## Communicating with the user
+
+The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
+
+So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+
+- "evaluation" and "benchmark" are borderline, but OK
+- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+
+It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+
+---
+
+## Creating a skill
+
+### Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+
+1. What should this skill enable Claude to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+
+### Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+
+Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+
+### Write the SKILL.md
+
+Based on the user interview, fill in these components:
+
+- **name**: Skill identifier
+- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+- **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **the rest of the skill :)**
+
+### Skill Writing Guide
+
+#### Anatomy of a Skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+└── Bundled Resources (optional)
+    ├── scripts/    - Executable code for deterministic/repetitive tasks
+    ├── references/ - Docs loaded into context as needed
+    └── assets/     - Files used in output (templates, icons, fonts)
+```
+
+#### Progressive Disclosure
+
+Skills use a three-level loading system:
+1. **Metadata** (name + description) - Always in context (~100 words)
+2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
+3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
+
+These word counts are approximate and you can feel free to go longer if needed.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Reference files clearly from SKILL.md with guidance on when to read them
+- For large reference files (>300 lines), include a table of contents
+
+**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+```
+cloud-deploy/
+├── SKILL.md (workflow + selection)
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+Claude reads only the relevant reference file.
+
+#### Principle of Lack of Surprise
+
+This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+
+#### Writing Patterns
+
+Prefer using the imperative form in instructions.
+
+**Defining output formats** - You can do it like this:
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+### Writing Style
+
+Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+
+### Test Cases
+
+After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+
+Save test cases to `evals/evals.json`. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's task prompt",
+      "expected_output": "Description of expected result",
+      "files": []
+    }
+  ]
+}
+```
+
+See `references/schemas.md` for the full schema (including the `assertions` field, which you'll add later).
+
+## Running and evaluating test cases
+
+This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+
+Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+
+### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
+
+For each test case, spawn two subagents in the same turn — one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+
+**With-skill run:**
+
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
+- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
+```
+
+**Baseline run** (same prompt, but the baseline depends on context):
+- **Creating a new skill**: no skill at all. Same prompt, no skill path, save to `without_skill/outputs/`.
+- **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Save to `old_skill/outputs/`.
+
+Write an `eval_metadata.json` for each test case (assertions can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "The user's task prompt",
+  "assertions": []
+}
+```
+
+### Step 2: While runs are in progress, draft assertions
+
+Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+
+Good assertions are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force assertions onto things that need human judgment.
+
+Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
+
+### Step 3: As runs complete, capture timing data
+
+When each subagent task completes, you receive a notification containing `total_tokens` and `duration_ms`. Save this data immediately to `timing.json` in the run directory:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
+
+### Step 4: Grade, aggregate, and launch the viewer
+
+Once all runs are done:
+
+1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
+
+2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
+   ```bash
+   python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
+   ```
+   This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
+Put each with_skill version before its baseline counterpart.
+
+3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+
+4. **Launch the viewer** with both qualitative outputs and quantitative data:
+   ```bash
+   nohup python <skill-creator-path>/eval-viewer/generate_review.py \
+     <workspace>/iteration-N \
+     --skill-name "my-skill" \
+     --benchmark <workspace>/iteration-N/benchmark.json \
+     > /dev/null 2>&1 &
+   VIEWER_PID=$!
+   ```
+   For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
+
+   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
+
+Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
+
+5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+
+### What the user sees in the viewer
+
+The "Outputs" tab shows one test case at a time:
+- **Prompt**: the task that was given
+- **Output**: the files the skill produced, rendered inline where possible
+- **Previous Output** (iteration 2+): collapsed section showing last iteration's output
+- **Formal Grades** (if grading was run): collapsed section showing assertion pass/fail
+- **Feedback**: a textbox that auto-saves as they type
+- **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
+
+The "Benchmark" tab shows the stats summary: pass rates, timing, and token usage for each configuration, with per-eval breakdowns and analyst observations.
+
+Navigation is via prev/next buttons or arrow keys. When done, they click "Submit All Reviews" which saves all feedback to `feedback.json`.
+
+### Step 5: Read the feedback
+
+When the user tells you they're done, read `feedback.json`:
+
+```json
+{
+  "reviews": [
+    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
+    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
+    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
+  ],
+  "status": "complete"
+}
+```
+
+Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
+
+Kill the viewer server when you're done with it:
+
+```bash
+kill $VIEWER_PID 2>/dev/null
+```
+
+---
+
+## Improving the skill
+
+This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+
+### How to think about improvements
+
+1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+
+4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+
+This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
+
+### The iteration loop
+
+After improving the skill:
+
+1. Apply your improvements to the skill
+2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
+3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
+4. Wait for the user to review and tell you they're done
+5. Read the new feedback, improve again, repeat
+
+Keep going until:
+- The user says they're happy
+- The feedback is all empty (everything looks good)
+- You're not making meaningful progress
+
+---
+
+## Advanced: Blind comparison
+
+For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
+
+This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
+
+---
+
+## Description Optimization
+
+The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+
+### Step 1: Generate trigger eval queries
+
+Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save as JSON:
+
+```json
+[
+  {"query": "the user prompt", "should_trigger": true},
+  {"query": "another prompt", "should_trigger": false}
+]
+```
+
+The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
+
+Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+
+Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+
+For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+
+For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+
+The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
+
+### Step 2: Review with user
+
+Present the eval set to the user for review using the HTML template:
+
+1. Read the template from `assets/eval_review.html`
+2. Replace the placeholders:
+   - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
+   - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
+   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
+3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
+4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
+5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
+
+This step matters — bad eval queries lead to bad descriptions.
+
+### Step 3: Run the optimization loop
+
+Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
+
+Save the eval set to the workspace, then run in the background:
+
+```bash
+python -m scripts.run_loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --max-iterations 5 \
+  --verbose
+```
+
+Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
+
+While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
+
+This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+
+### How skill triggering works
+
+Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
+
+This means your eval queries should be substantive enough that Claude would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
+
+### Step 4: Apply the result
+
+Take `best_description` from the JSON output and update the skill's SKILL.md frontmatter. Show the user before/after and report the scores.
+
+---
+
+### Package and Present (only if `present_files` tool is available)
+
+Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+
+```bash
+python -m scripts.package_skill <path/to/skill-folder>
+```
+
+After packaging, direct the user to the resulting `.skill` file path so they can install it.
+
+---
+
+## Claude.ai-specific instructions
+
+In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
+
+**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check — and the human review step compensates. Skip the baseline runs — just use the skill to complete the task as requested.
+
+**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
+
+**Benchmarking**: Skip the quantitative benchmarking — it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
+
+**The iteration loop**: Same as before — improve the skill, rerun the test cases, ask for feedback — just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
+
+**Description optimization**: This section requires the `claude` CLI tool (specifically `claude -p`) which is only available in Claude Code. Skip it if you're on Claude.ai.
+
+**Blind comparison**: Requires subagents. Skip it.
+
+**Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
+
+**Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
+- **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
+- **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
+- **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
+
+---
+
+## Cowork-Specific Instructions
+
+If you're in Cowork, the main things to know are:
+
+- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
+- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
+- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
+- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
+- Packaging works — `package_skill.py` just needs Python and a filesystem.
+- Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
+- **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. Follow the update guidance in the claude.ai section above.
+
+---
+
+## Reference files
+
+The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+
+- `agents/grader.md` — How to evaluate assertions against outputs
+- `agents/comparator.md` — How to do blind A/B comparison between two outputs
+- `agents/analyzer.md` — How to analyze why one version beat another
+
+The references/ directory has additional documentation:
+- `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
+
+---
+
+Repeating one more time the core loop here for emphasis:
+
+- Figure out what the skill is about
+- Draft or edit the skill
+- Run claude-with-access-to-the-skill on test prompts
+- With the user, evaluate the outputs:
+  - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
+  - Run quantitative evals
+- Repeat until you and the user are satisfied
+- Package the final skill and return it to the user.
+
+Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `eval-viewer/generate_review.py` so human can review test cases" in your TodoList to make sure it happens.
+
+Good luck!

--- a/.agents/skills/skill-creator/agents/analyzer.md
+++ b/.agents/skills/skill-creator/agents/analyzer.md
@@ -1,0 +1,274 @@
+# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the skill that produced the winning output
+- **winner_transcript_path**: Path to the execution transcript for the winner
+- **loser_skill_path**: Path to the skill that produced the losing output
+- **loser_transcript_path**: Path to the execution transcript for the loser
+- **comparison_result_path**: Path to the blind comparator's output JSON
+- **output_path**: Where to save the analysis results
+
+## Process
+
+### Step 1: Read Comparison Result
+
+1. Read the blind comparator's output at comparison_result_path
+2. Note the winning side (A or B), the reasoning, and any scores
+3. Understand what the comparator valued in the winning output
+
+### Step 2: Read Both Skills
+
+1. Read the winner skill's SKILL.md and key referenced files
+2. Read the loser skill's SKILL.md and key referenced files
+3. Identify structural differences:
+   - Instructions clarity and specificity
+   - Script/tool usage patterns
+   - Example coverage
+   - Edge case handling
+
+### Step 3: Read Both Transcripts
+
+1. Read the winner's transcript
+2. Read the loser's transcript
+3. Compare execution patterns:
+   - How closely did each follow their skill's instructions?
+   - What tools were used differently?
+   - Where did the loser diverge from optimal behavior?
+   - Did either encounter errors or make recovery attempts?
+
+### Step 4: Analyze Instruction Following
+
+For each transcript, evaluate:
+- Did the agent follow the skill's explicit instructions?
+- Did the agent use the skill's provided tools/scripts?
+- Were there missed opportunities to leverage skill content?
+- Did the agent add unnecessary steps not in the skill?
+
+Score instruction following 1-10 and note specific issues.
+
+### Step 5: Identify Winner Strengths
+
+Determine what made the winner better:
+- Clearer instructions that led to better behavior?
+- Better scripts/tools that produced better output?
+- More comprehensive examples that guided edge cases?
+- Better error handling guidance?
+
+Be specific. Quote from skills/transcripts where relevant.
+
+### Step 6: Identify Loser Weaknesses
+
+Determine what held the loser back:
+- Ambiguous instructions that led to suboptimal choices?
+- Missing tools/scripts that forced workarounds?
+- Gaps in edge case coverage?
+- Poor error handling that caused failures?
+
+### Step 7: Generate Improvement Suggestions
+
+Based on the analysis, produce actionable suggestions for improving the loser skill:
+- Specific instruction changes to make
+- Tools/scripts to add or modify
+- Examples to include
+- Edge cases to address
+
+Prioritize by impact. Focus on changes that would have changed the outcome.
+
+### Step 8: Write Analysis Results
+
+Save structured analysis to `{output_path}`.
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors",
+    "Explicit guidance on fallback behavior when OCR fails"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise and made errors",
+    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": [
+        "Minor: skipped optional logging step"
+      ]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3",
+        "Missed the 'always validate output' instruction"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    },
+    {
+      "priority": "high",
+      "category": "tools",
+      "suggestion": "Add validate_output.py script similar to winner skill's validation approach",
+      "expected_impact": "Would catch formatting errors before final output"
+    },
+    {
+      "priority": "medium",
+      "category": "error_handling",
+      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
+      "expected_impact": "Would prevent early failure on difficult documents"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+  }
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
+- **Be actionable**: Suggestions should be concrete changes, not vague advice
+- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
+- **Prioritize by impact**: Which changes would most likely have changed the outcome?
+- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
+- **Stay objective**: Analyze what happened, don't editorialize
+- **Think about generalization**: Would this improvement help on other evals too?
+
+## Categories for Suggestions
+
+Use these categories to organize improvement suggestions:
+
+| Category | Description |
+|----------|-------------|
+| `instructions` | Changes to the skill's prose instructions |
+| `tools` | Scripts, templates, or utilities to add/modify |
+| `examples` | Example inputs/outputs to include |
+| `error_handling` | Guidance for handling failures |
+| `structure` | Reorganization of skill content |
+| `references` | External docs or resources to add |
+
+## Priority Levels
+
+- **high**: Would likely change the outcome of this comparison
+- **medium**: Would improve quality but may not change win/loss
+- **low**: Nice to have, marginal improvement
+
+---
+
+# Analyzing Benchmark Results
+
+When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+
+## Role
+
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
+- **skill_path**: Path to the skill being benchmarked
+- **output_path**: Where to save the notes (as JSON array of strings)
+
+## Process
+
+### Step 1: Read Benchmark Data
+
+1. Read the benchmark.json containing all run results
+2. Note the configurations tested (with_skill, without_skill)
+3. Understand the run_summary aggregates already calculated
+
+### Step 2: Analyze Per-Assertion Patterns
+
+For each expectation across all runs:
+- Does it **always pass** in both configurations? (may not differentiate skill value)
+- Does it **always fail** in both configurations? (may be broken or beyond capability)
+- Does it **always pass with skill but fail without**? (skill clearly adds value here)
+- Does it **always fail with skill but pass without**? (skill may be hurting)
+- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+
+### Step 3: Analyze Cross-Eval Patterns
+
+Look for patterns across evals:
+- Are certain eval types consistently harder/easier?
+- Do some evals show high variance while others are stable?
+- Are there surprising results that contradict expectations?
+
+### Step 4: Analyze Metrics Patterns
+
+Look at time_seconds, tokens, tool_calls:
+- Does the skill significantly increase execution time?
+- Is there high variance in resource usage?
+- Are there outlier runs that skew the aggregates?
+
+### Step 5: Generate Notes
+
+Write freeform observations as a list of strings. Each note should:
+- State a specific observation
+- Be grounded in the data (not speculation)
+- Help the user understand something the aggregate metrics don't show
+
+Examples:
+- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
+- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
+- "Skill adds 13s average execution time but improves pass rate by 50%"
+- "Token usage is 80% higher with skill, primarily due to script output parsing"
+- "All 3 without-skill runs for eval 1 produced empty output"
+
+### Step 6: Write Notes
+
+Save notes to `{output_path}` as a JSON array of strings:
+
+```json
+[
+  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
+  "Without-skill runs consistently fail on table extraction expectations",
+  "Skill adds 13s average execution time but improves pass rate by 50%"
+]
+```
+
+## Guidelines
+
+**DO:**
+- Report what you observe in the data
+- Be specific about which evals, expectations, or runs you're referring to
+- Note patterns that aggregate metrics would hide
+- Provide context that helps interpret the numbers
+
+**DO NOT:**
+- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
+- Make subjective quality judgments ("the output was good/bad")
+- Speculate about causes without evidence
+- Repeat information already in the run_summary aggregates

--- a/.agents/skills/skill-creator/agents/comparator.md
+++ b/.agents/skills/skill-creator/agents/comparator.md
@@ -1,0 +1,202 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill produced them.
+
+## Role
+
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+
+Your judgment is based purely on output quality and task completion.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **output_a_path**: Path to the first output file or directory
+- **output_b_path**: Path to the second output file or directory
+- **eval_prompt**: The original task/prompt that was executed
+- **expectations**: List of expectations to check (optional - may be empty)
+
+## Process
+
+### Step 1: Read Both Outputs
+
+1. Examine output A (file or directory)
+2. Examine output B (file or directory)
+3. Note the type, structure, and content of each
+4. If outputs are directories, examine all relevant files inside
+
+### Step 2: Understand the Task
+
+1. Read the eval_prompt carefully
+2. Identify what the task requires:
+   - What should be produced?
+   - What qualities matter (accuracy, completeness, format)?
+   - What would distinguish a good output from a poor one?
+
+### Step 3: Generate Evaluation Rubric
+
+Based on the task, generate a rubric with two dimensions:
+
+**Content Rubric** (what the output contains):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Correctness | Major errors | Minor errors | Fully correct |
+| Completeness | Missing key elements | Mostly complete | All elements present |
+| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+**Structure Rubric** (how the output is organized):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Organization | Disorganized | Reasonably organized | Clear, logical structure |
+| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
+| Usability | Difficult to use | Usable with effort | Easy to use |
+
+Adapt criteria to the specific task. For example:
+- PDF form → "Field alignment", "Text readability", "Data placement"
+- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
+- Data output → "Schema correctness", "Data types", "Completeness"
+
+### Step 4: Evaluate Each Output Against the Rubric
+
+For each output (A and B):
+
+1. **Score each criterion** on the rubric (1-5 scale)
+2. **Calculate dimension totals**: Content score, Structure score
+3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+
+### Step 5: Check Assertions (if provided)
+
+If expectations are provided:
+
+1. Check each expectation against output A
+2. Check each expectation against output B
+3. Count pass rates for each output
+4. Use expectation scores as secondary evidence (not the primary decision factor)
+
+### Step 6: Determine the Winner
+
+Compare A and B based on (in priority order):
+
+1. **Primary**: Overall rubric score (content + structure)
+2. **Secondary**: Assertion pass rates (if applicable)
+3. **Tiebreaker**: If truly equal, declare a TIE
+
+Be decisive - ties should be rare. One output is usually better, even if marginally.
+
+### Step 7: Write Comparison Results
+
+Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": true},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": false},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+If no expectations were provided, omit the `expectation_results` field entirely.
+
+## Field Descriptions
+
+- **winner**: "A", "B", or "TIE"
+- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
+- **rubric**: Structured rubric evaluation for each output
+  - **content**: Scores for content criteria (correctness, completeness, accuracy)
+  - **structure**: Scores for structure criteria (organization, formatting, usability)
+  - **content_score**: Average of content criteria (1-5)
+  - **structure_score**: Average of structure criteria (1-5)
+  - **overall_score**: Combined score scaled to 1-10
+- **output_quality**: Summary quality assessment
+  - **score**: 1-10 rating (should match rubric overall_score)
+  - **strengths**: List of positive aspects
+  - **weaknesses**: List of issues or shortcomings
+- **expectation_results**: (Only if expectations provided)
+  - **passed**: Number of expectations that passed
+  - **total**: Total number of expectations
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+  - **details**: Individual expectation results
+
+## Guidelines
+
+- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
+- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
+- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
+- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
+- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
+- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/.agents/skills/skill-creator/agents/grader.md
+++ b/.agents/skills/skill-creator/agents/grader.md
@@ -1,0 +1,223 @@
+# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript (markdown file)
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+### Step 1: Read the Transcript
+
+1. Read the transcript file completely
+2. Note the eval prompt, execution steps, and final result
+3. Identify any issues or errors documented
+
+### Step 2: Examine Output Files
+
+1. List files in outputs_dir
+2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
+3. Note contents, structure, and quality
+
+### Step 3: Evaluate Each Assertion
+
+For each expectation:
+
+1. **Search for evidence** in the transcript and outputs
+2. **Determine verdict**:
+   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
+   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
+3. **Cite the evidence**: Quote the specific text or describe what you found
+
+### Step 4: Extract and Verify Claims
+
+Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+
+1. **Extract claims** from the transcript and outputs:
+   - Factual statements ("The form has 12 fields")
+   - Process claims ("Used pypdf to fill the form")
+   - Quality claims ("All fields were filled correctly")
+
+2. **Verify each claim**:
+   - **Factual claims**: Can be checked against the outputs or external sources
+   - **Process claims**: Can be verified from the transcript
+   - **Quality claims**: Evaluate whether the claim is justified
+
+3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+
+This catches issues that predefined expectations might miss.
+
+### Step 5: Read User Notes
+
+If `{outputs_dir}/user_notes.md` exists:
+1. Read it and note any uncertainties or issues flagged by the executor
+2. Include relevant concerns in the grading output
+3. These may reveal problems even when expectations pass
+
+### Step 6: Critique the Evals
+
+After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+
+Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+
+Suggestions worth raising:
+- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed — good or bad — that no assertion covers at all
+- An assertion that can't actually be verified from the available outputs
+
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+
+### Step 7: Write Grading Results
+
+Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+
+## Grading Criteria
+
+**PASS when**:
+- The transcript or outputs clearly demonstrate the expectation is true
+- Specific evidence can be cited
+- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+
+**FAIL when**:
+- No evidence found for the expectation
+- Evidence contradicts the expectation
+- The expectation cannot be verified from available information
+- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the assertion by coincidence rather than by actually doing the work
+
+**When uncertain**: The burden of proof to pass is on the expectation.
+
+### Step 8: Read Executor Metrics and Timing
+
+1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
+2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    },
+    {
+      "text": "The assistant used the skill's OCR script",
+      "passed": true,
+      "evidence": "Transcript Step 2 shows: 'Tool: Bash - python ocr_script.py image.png'"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    },
+    {
+      "claim": "All required fields were populated",
+      "type": "quality",
+      "verified": false,
+      "evidence": "Reference section was left blank despite data being available"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
+      },
+      {
+        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+  }
+}
+```
+
+## Field Descriptions
+
+- **expectations**: Array of graded expectations
+  - **text**: The original expectation text
+  - **passed**: Boolean - true if expectation passes
+  - **evidence**: Specific quote or description supporting the verdict
+- **summary**: Aggregate statistics
+  - **passed**: Count of passed expectations
+  - **failed**: Count of failed expectations
+  - **total**: Total expectations evaluated
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+- **execution_metrics**: Copied from executor's metrics.json (if available)
+  - **output_chars**: Total character count of output files (proxy for tokens)
+  - **transcript_chars**: Character count of transcript
+- **timing**: Wall clock timing from timing.json (if available)
+  - **executor_duration_seconds**: Time spent in executor subagent
+  - **total_duration_seconds**: Total elapsed time for the run
+- **claims**: Extracted and verified claims from the output
+  - **claim**: The statement being verified
+  - **type**: "factual", "process", or "quality"
+  - **verified**: Boolean - whether the claim holds
+  - **evidence**: Supporting or contradicting evidence
+- **user_notes_summary**: Issues flagged by the executor
+  - **uncertainties**: Things the executor wasn't sure about
+  - **needs_review**: Items requiring human attention
+  - **workarounds**: Places where the skill didn't work as expected
+- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **Be thorough**: Check both transcript and output files
+- **Be consistent**: Apply the same standard to each expectation
+- **Explain failures**: Make it clear why evidence was insufficient
+- **No partial credit**: Each expectation is pass or fail, not partial

--- a/.agents/skills/skill-creator/assets/eval_review.html
+++ b/.agents/skills/skill-creator/assets/eval_review.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Set Review - __SKILL_NAME_PLACEHOLDER__</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Lora', Georgia, serif; background: #faf9f5; padding: 2rem; color: #141413; }
+    h1 { font-family: 'Poppins', sans-serif; margin-bottom: 0.5rem; font-size: 1.5rem; }
+    .description { color: #b0aea5; margin-bottom: 1.5rem; font-style: italic; max-width: 900px; }
+    .controls { margin-bottom: 1rem; display: flex; gap: 0.5rem; }
+    .btn { font-family: 'Poppins', sans-serif; padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-size: 0.875rem; font-weight: 500; }
+    .btn-add { background: #6a9bcc; color: white; }
+    .btn-add:hover { background: #5889b8; }
+    .btn-export { background: #d97757; color: white; }
+    .btn-export:hover { background: #c4613f; }
+    table { width: 100%; max-width: 1100px; border-collapse: collapse; background: white; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    th { font-family: 'Poppins', sans-serif; background: #141413; color: #faf9f5; padding: 0.75rem 1rem; text-align: left; font-size: 0.875rem; }
+    td { padding: 0.75rem 1rem; border-bottom: 1px solid #e8e6dc; vertical-align: top; }
+    tr:nth-child(even) td { background: #faf9f5; }
+    tr:hover td { background: #f3f1ea; }
+    .section-header td { background: #e8e6dc; font-family: 'Poppins', sans-serif; font-weight: 500; font-size: 0.8rem; color: #141413; text-transform: uppercase; letter-spacing: 0.05em; }
+    .query-input { width: 100%; padding: 0.4rem; border: 1px solid #e8e6dc; border-radius: 4px; font-size: 0.875rem; font-family: 'Lora', Georgia, serif; resize: vertical; min-height: 60px; }
+    .query-input:focus { outline: none; border-color: #d97757; box-shadow: 0 0 0 2px rgba(217,119,87,0.15); }
+    .toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
+    .toggle input { opacity: 0; width: 0; height: 0; }
+    .toggle .slider { position: absolute; inset: 0; background: #b0aea5; border-radius: 24px; cursor: pointer; transition: 0.2s; }
+    .toggle .slider::before { content: ""; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: white; border-radius: 50%; transition: 0.2s; }
+    .toggle input:checked + .slider { background: #d97757; }
+    .toggle input:checked + .slider::before { transform: translateX(20px); }
+    .btn-delete { background: #c44; color: white; padding: 0.3rem 0.6rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.75rem; font-family: 'Poppins', sans-serif; }
+    .btn-delete:hover { background: #a33; }
+    .summary { margin-top: 1rem; color: #b0aea5; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <h1>Eval Set Review: <span id="skill-name">__SKILL_NAME_PLACEHOLDER__</span></h1>
+  <p class="description">Current description: <span id="skill-desc">__SKILL_DESCRIPTION_PLACEHOLDER__</span></p>
+
+  <div class="controls">
+    <button class="btn btn-add" onclick="addRow()">+ Add Query</button>
+    <button class="btn btn-export" onclick="exportEvalSet()">Export Eval Set</button>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th style="width:65%">Query</th>
+        <th style="width:18%">Should Trigger</th>
+        <th style="width:10%">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="eval-body"></tbody>
+  </table>
+
+  <p class="summary" id="summary"></p>
+
+  <script>
+    const EVAL_DATA = __EVAL_DATA_PLACEHOLDER__;
+
+    let evalItems = [...EVAL_DATA];
+
+    function render() {
+      const tbody = document.getElementById('eval-body');
+      tbody.innerHTML = '';
+
+      // Sort: should-trigger first, then should-not-trigger
+      const sorted = evalItems
+        .map((item, origIdx) => ({ ...item, origIdx }))
+        .sort((a, b) => (b.should_trigger ? 1 : 0) - (a.should_trigger ? 1 : 0));
+
+      let lastGroup = null;
+      sorted.forEach(item => {
+        const group = item.should_trigger ? 'trigger' : 'no-trigger';
+        if (group !== lastGroup) {
+          const headerRow = document.createElement('tr');
+          headerRow.className = 'section-header';
+          headerRow.innerHTML = `<td colspan="3">${item.should_trigger ? 'Should Trigger' : 'Should NOT Trigger'}</td>`;
+          tbody.appendChild(headerRow);
+          lastGroup = group;
+        }
+
+        const idx = item.origIdx;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><textarea class="query-input" onchange="updateQuery(${idx}, this.value)">${escapeHtml(item.query)}</textarea></td>
+          <td>
+            <label class="toggle">
+              <input type="checkbox" ${item.should_trigger ? 'checked' : ''} onchange="updateTrigger(${idx}, this.checked)">
+              <span class="slider"></span>
+            </label>
+            <span style="margin-left:8px;font-size:0.8rem;color:#b0aea5">${item.should_trigger ? 'Yes' : 'No'}</span>
+          </td>
+          <td><button class="btn-delete" onclick="deleteRow(${idx})">Delete</button></td>
+        `;
+        tbody.appendChild(tr);
+      });
+      updateSummary();
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function updateQuery(idx, value) { evalItems[idx].query = value; updateSummary(); }
+    function updateTrigger(idx, value) { evalItems[idx].should_trigger = value; render(); }
+    function deleteRow(idx) { evalItems.splice(idx, 1); render(); }
+
+    function addRow() {
+      evalItems.push({ query: '', should_trigger: true });
+      render();
+      const inputs = document.querySelectorAll('.query-input');
+      inputs[inputs.length - 1].focus();
+    }
+
+    function updateSummary() {
+      const trigger = evalItems.filter(i => i.should_trigger).length;
+      const noTrigger = evalItems.filter(i => !i.should_trigger).length;
+      document.getElementById('summary').textContent =
+        `${evalItems.length} queries total: ${trigger} should trigger, ${noTrigger} should not trigger`;
+    }
+
+    function exportEvalSet() {
+      const valid = evalItems.filter(i => i.query.trim() !== '');
+      const data = valid.map(i => ({ query: i.query.trim(), should_trigger: i.should_trigger }));
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'eval_set.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/.agents/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.agents/skills/skill-creator/eval-viewer/generate_review.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Generate and serve a review page for eval results.
+
+Reads the workspace directory, discovers runs (directories with outputs/),
+embeds all output data into a self-contained HTML page, and serves it via
+a tiny HTTP server. Feedback auto-saves to feedback.json in the workspace.
+
+Usage:
+    python generate_review.py <workspace-path> [--port PORT] [--skill-name NAME]
+    python generate_review.py <workspace-path> --previous-feedback /path/to/old/feedback.json
+
+No dependencies beyond the Python stdlib are required.
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+# Files to exclude from output listings
+METADATA_FILES = {"transcript.md", "user_notes.md", "metrics.json"}
+
+# Extensions we render as inline text
+TEXT_EXTENSIONS = {
+    ".txt", ".md", ".json", ".csv", ".py", ".js", ".ts", ".tsx", ".jsx",
+    ".yaml", ".yml", ".xml", ".html", ".css", ".sh", ".rb", ".go", ".rs",
+    ".java", ".c", ".cpp", ".h", ".hpp", ".sql", ".r", ".toml",
+}
+
+# Extensions we render as inline images
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+# MIME type overrides for common types
+MIME_OVERRIDES = {
+    ".svg": "image/svg+xml",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def get_mime_type(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in MIME_OVERRIDES:
+        return MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"
+
+
+def find_runs(workspace: Path) -> list[dict]:
+    """Recursively find directories that contain an outputs/ subdirectory."""
+    runs: list[dict] = []
+    _find_runs_recursive(workspace, workspace, runs)
+    runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
+    return runs
+
+
+def _find_runs_recursive(root: Path, current: Path, runs: list[dict]) -> None:
+    if not current.is_dir():
+        return
+
+    outputs_dir = current / "outputs"
+    if outputs_dir.is_dir():
+        run = build_run(root, current)
+        if run:
+            runs.append(run)
+        return
+
+    skip = {"node_modules", ".git", "__pycache__", "skill", "inputs"}
+    for child in sorted(current.iterdir()):
+        if child.is_dir() and child.name not in skip:
+            _find_runs_recursive(root, child, runs)
+
+
+def build_run(root: Path, run_dir: Path) -> dict | None:
+    """Build a run dict with prompt, outputs, and grading data."""
+    prompt = ""
+    eval_id = None
+
+    # Try eval_metadata.json
+    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+        if candidate.exists():
+            try:
+                metadata = json.loads(candidate.read_text())
+                prompt = metadata.get("prompt", "")
+                eval_id = metadata.get("eval_id")
+            except (json.JSONDecodeError, OSError):
+                pass
+            if prompt:
+                break
+
+    # Fall back to transcript.md
+    if not prompt:
+        for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
+            if candidate.exists():
+                try:
+                    text = candidate.read_text()
+                    match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
+                    if match:
+                        prompt = match.group(1).strip()
+                except OSError:
+                    pass
+                if prompt:
+                    break
+
+    if not prompt:
+        prompt = "(No prompt found)"
+
+    run_id = str(run_dir.relative_to(root)).replace("/", "-").replace("\\", "-")
+
+    # Collect output files
+    outputs_dir = run_dir / "outputs"
+    output_files: list[dict] = []
+    if outputs_dir.is_dir():
+        for f in sorted(outputs_dir.iterdir()):
+            if f.is_file() and f.name not in METADATA_FILES:
+                output_files.append(embed_file(f))
+
+    # Load grading if present
+    grading = None
+    for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
+        if candidate.exists():
+            try:
+                grading = json.loads(candidate.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+            if grading:
+                break
+
+    return {
+        "id": run_id,
+        "prompt": prompt,
+        "eval_id": eval_id,
+        "outputs": output_files,
+        "grading": grading,
+    }
+
+
+def embed_file(path: Path) -> dict:
+    """Read a file and return an embedded representation."""
+    ext = path.suffix.lower()
+    mime = get_mime_type(path)
+
+    if ext in TEXT_EXTENSIONS:
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            content = "(Error reading file)"
+        return {
+            "name": path.name,
+            "type": "text",
+            "content": content,
+        }
+    elif ext in IMAGE_EXTENSIONS:
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "image",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".pdf":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "pdf",
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".xlsx":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "xlsx",
+            "data_b64": b64,
+        }
+    else:
+        # Binary / unknown — base64 download link
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "binary",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+
+
+def load_previous_iteration(workspace: Path) -> dict[str, dict]:
+    """Load previous iteration's feedback and outputs.
+
+    Returns a map of run_id -> {"feedback": str, "outputs": list[dict]}.
+    """
+    result: dict[str, dict] = {}
+
+    # Load feedback
+    feedback_map: dict[str, str] = {}
+    feedback_path = workspace / "feedback.json"
+    if feedback_path.exists():
+        try:
+            data = json.loads(feedback_path.read_text())
+            feedback_map = {
+                r["run_id"]: r["feedback"]
+                for r in data.get("reviews", [])
+                if r.get("feedback", "").strip()
+            }
+        except (json.JSONDecodeError, OSError, KeyError):
+            pass
+
+    # Load runs (to get outputs)
+    prev_runs = find_runs(workspace)
+    for run in prev_runs:
+        result[run["id"]] = {
+            "feedback": feedback_map.get(run["id"], ""),
+            "outputs": run.get("outputs", []),
+        }
+
+    # Also add feedback for run_ids that had feedback but no matching run
+    for run_id, fb in feedback_map.items():
+        if run_id not in result:
+            result[run_id] = {"feedback": fb, "outputs": []}
+
+    return result
+
+
+def generate_html(
+    runs: list[dict],
+    skill_name: str,
+    previous: dict[str, dict] | None = None,
+    benchmark: dict | None = None,
+) -> str:
+    """Generate the complete standalone HTML page with embedded data."""
+    template_path = Path(__file__).parent / "viewer.html"
+    template = template_path.read_text()
+
+    # Build previous_feedback and previous_outputs maps for the template
+    previous_feedback: dict[str, str] = {}
+    previous_outputs: dict[str, list[dict]] = {}
+    if previous:
+        for run_id, data in previous.items():
+            if data.get("feedback"):
+                previous_feedback[run_id] = data["feedback"]
+            if data.get("outputs"):
+                previous_outputs[run_id] = data["outputs"]
+
+    embedded = {
+        "skill_name": skill_name,
+        "runs": runs,
+        "previous_feedback": previous_feedback,
+        "previous_outputs": previous_outputs,
+    }
+    if benchmark:
+        embedded["benchmark"] = benchmark
+
+    data_json = json.dumps(embedded)
+
+    return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
+
+
+# ---------------------------------------------------------------------------
+# HTTP server (stdlib only, zero dependencies)
+# ---------------------------------------------------------------------------
+
+def _kill_port(port: int) -> None:
+    """Kill any process listening on the given port."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for pid_str in result.stdout.strip().split("\n"):
+            if pid_str.strip():
+                try:
+                    os.kill(int(pid_str.strip()), signal.SIGTERM)
+                except (ProcessLookupError, ValueError):
+                    pass
+        if result.stdout.strip():
+            time.sleep(0.5)
+    except subprocess.TimeoutExpired:
+        pass
+    except FileNotFoundError:
+        print("Note: lsof not found, cannot check if port is in use", file=sys.stderr)
+
+class ReviewHandler(BaseHTTPRequestHandler):
+    """Serves the review HTML and handles feedback saves.
+
+    Regenerates the HTML on each page load so that refreshing the browser
+    picks up new eval outputs without restarting the server.
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        skill_name: str,
+        feedback_path: Path,
+        previous: dict[str, dict],
+        benchmark_path: Path | None,
+        *args,
+        **kwargs,
+    ):
+        self.workspace = workspace
+        self.skill_name = skill_name
+        self.feedback_path = feedback_path
+        self.previous = previous
+        self.benchmark_path = benchmark_path
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/" or self.path == "/index.html":
+            # Regenerate HTML on each request (re-scans workspace for new outputs)
+            runs = find_runs(self.workspace)
+            benchmark = None
+            if self.benchmark_path and self.benchmark_path.exists():
+                try:
+                    benchmark = json.loads(self.benchmark_path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            html = generate_html(runs, self.skill_name, self.previous, benchmark)
+            content = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        elif self.path == "/api/feedback":
+            data = b"{}"
+            if self.feedback_path.exists():
+                data = self.feedback_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path == "/api/feedback":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body)
+                if not isinstance(data, dict) or "reviews" not in data:
+                    raise ValueError("Expected JSON object with 'reviews' key")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                resp = b'{"ok":true}'
+                self.send_response(200)
+            except (json.JSONDecodeError, OSError, ValueError) as e:
+                resp = json.dumps({"error": str(e)}).encode()
+                self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+        else:
+            self.send_error(404)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Suppress request logging to keep terminal clean
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and serve eval review")
+    parser.add_argument("workspace", type=Path, help="Path to workspace directory")
+    parser.add_argument("--port", "-p", type=int, default=3117, help="Server port (default: 3117)")
+    parser.add_argument("--skill-name", "-n", type=str, default=None, help="Skill name for header")
+    parser.add_argument(
+        "--previous-workspace", type=Path, default=None,
+        help="Path to previous iteration's workspace (shows old outputs and feedback as context)",
+    )
+    parser.add_argument(
+        "--benchmark", type=Path, default=None,
+        help="Path to benchmark.json to show in the Benchmark tab",
+    )
+    parser.add_argument(
+        "--static", "-s", type=Path, default=None,
+        help="Write standalone HTML to this path instead of starting a server",
+    )
+    args = parser.parse_args()
+
+    workspace = args.workspace.resolve()
+    if not workspace.is_dir():
+        print(f"Error: {workspace} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    runs = find_runs(workspace)
+    if not runs:
+        print(f"No runs found in {workspace}", file=sys.stderr)
+        sys.exit(1)
+
+    skill_name = args.skill_name or workspace.name.replace("-workspace", "")
+    feedback_path = workspace / "feedback.json"
+
+    previous: dict[str, dict] = {}
+    if args.previous_workspace:
+        previous = load_previous_iteration(args.previous_workspace.resolve())
+
+    benchmark_path = args.benchmark.resolve() if args.benchmark else None
+    benchmark = None
+    if benchmark_path and benchmark_path.exists():
+        try:
+            benchmark = json.loads(benchmark_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if args.static:
+        html = generate_html(runs, skill_name, previous, benchmark)
+        args.static.parent.mkdir(parents=True, exist_ok=True)
+        args.static.write_text(html)
+        print(f"\n  Static viewer written to: {args.static}\n")
+        sys.exit(0)
+
+    # Kill any existing process on the target port
+    port = args.port
+    _kill_port(port)
+    handler = partial(ReviewHandler, workspace, skill_name, feedback_path, previous, benchmark_path)
+    try:
+        server = HTTPServer(("127.0.0.1", port), handler)
+    except OSError:
+        # Port still in use after kill attempt — find a free one
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+
+    url = f"http://localhost:{port}"
+    print(f"\n  Eval Viewer")
+    print(f"  ─────────────────────────────────")
+    print(f"  URL:       {url}")
+    print(f"  Workspace: {workspace}")
+    print(f"  Feedback:  {feedback_path}")
+    if previous:
+        print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
+    if benchmark_path:
+        print(f"  Benchmark: {benchmark_path}")
+    print(f"\n  Press Ctrl+C to stop.\n")
+
+    webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/eval-viewer/viewer.html
+++ b/.agents/skills/skill-creator/eval-viewer/viewer.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    /*__EMBEDDED_DATA__*/
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/.agents/skills/skill-creator/references/schemas.md
+++ b/.agents/skills/skill-creator/references/schemas.md
@@ -1,0 +1,430 @@
+# JSON Schemas
+
+This document defines the JSON schemas used by skill-creator.
+
+---
+
+## evals.json
+
+Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's example prompt",
+      "expected_output": "Description of expected result",
+      "files": ["evals/files/sample1.pdf"],
+      "expectations": [
+        "The output includes X",
+        "The skill used script Y"
+      ]
+    }
+  ]
+}
+```
+
+**Fields:**
+- `skill_name`: Name matching the skill's frontmatter
+- `evals[].id`: Unique integer identifier
+- `evals[].prompt`: The task to execute
+- `evals[].expected_output`: Human-readable description of success
+- `evals[].files`: Optional list of input file paths (relative to skill root)
+- `evals[].expectations`: List of verifiable statements
+
+---
+
+## history.json
+
+Tracks version progression in Improve mode. Located at workspace root.
+
+```json
+{
+  "started_at": "2026-01-15T10:30:00Z",
+  "skill_name": "pdf",
+  "current_best": "v2",
+  "iterations": [
+    {
+      "version": "v0",
+      "parent": null,
+      "expectation_pass_rate": 0.65,
+      "grading_result": "baseline",
+      "is_current_best": false
+    },
+    {
+      "version": "v1",
+      "parent": "v0",
+      "expectation_pass_rate": 0.75,
+      "grading_result": "won",
+      "is_current_best": false
+    },
+    {
+      "version": "v2",
+      "parent": "v1",
+      "expectation_pass_rate": 0.85,
+      "grading_result": "won",
+      "is_current_best": true
+    }
+  ]
+}
+```
+
+**Fields:**
+- `started_at`: ISO timestamp of when improvement started
+- `skill_name`: Name of the skill being improved
+- `current_best`: Version identifier of the best performer
+- `iterations[].version`: Version identifier (v0, v1, ...)
+- `iterations[].parent`: Parent version this was derived from
+- `iterations[].expectation_pass_rate`: Pass rate from grading
+- `iterations[].grading_result`: "baseline", "won", "lost", or "tie"
+- `iterations[].is_current_best`: Whether this is the current best version
+
+---
+
+## grading.json
+
+Output from the grader agent. Located at `<run-dir>/grading.json`.
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness."
+  }
+}
+```
+
+**Fields:**
+- `expectations[]`: Graded expectations with evidence
+- `summary`: Aggregate pass/fail counts
+- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
+- `timing`: Wall clock timing (from timing.json)
+- `claims`: Extracted and verified claims from the output
+- `user_notes_summary`: Issues flagged by the executor
+- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+
+---
+
+## metrics.json
+
+Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
+
+```json
+{
+  "tool_calls": {
+    "Read": 5,
+    "Write": 2,
+    "Bash": 8,
+    "Edit": 1,
+    "Glob": 2,
+    "Grep": 0
+  },
+  "total_tool_calls": 18,
+  "total_steps": 6,
+  "files_created": ["filled_form.pdf", "field_values.json"],
+  "errors_encountered": 0,
+  "output_chars": 12450,
+  "transcript_chars": 3200
+}
+```
+
+**Fields:**
+- `tool_calls`: Count per tool type
+- `total_tool_calls`: Sum of all tool calls
+- `total_steps`: Number of major execution steps
+- `files_created`: List of output files created
+- `errors_encountered`: Number of errors during execution
+- `output_chars`: Total character count of output files
+- `transcript_chars`: Character count of transcript
+
+---
+
+## timing.json
+
+Wall clock timing for a run. Located at `<run-dir>/timing.json`.
+
+**How to capture:** When a subagent task completes, the task notification includes `total_tokens` and `duration_ms`. Save these immediately — they are not persisted anywhere else and cannot be recovered after the fact.
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3,
+  "executor_start": "2026-01-15T10:30:00Z",
+  "executor_end": "2026-01-15T10:32:45Z",
+  "executor_duration_seconds": 165.0,
+  "grader_start": "2026-01-15T10:32:46Z",
+  "grader_end": "2026-01-15T10:33:12Z",
+  "grader_duration_seconds": 26.0
+}
+```
+
+---
+
+## benchmark.json
+
+Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
+
+```json
+{
+  "metadata": {
+    "skill_name": "pdf",
+    "skill_path": "/path/to/pdf",
+    "executor_model": "claude-sonnet-4-20250514",
+    "analyzer_model": "most-capable-model",
+    "timestamp": "2026-01-15T10:30:00Z",
+    "evals_run": [1, 2, 3],
+    "runs_per_configuration": 3
+  },
+
+  "runs": [
+    {
+      "eval_id": 1,
+      "eval_name": "Ocean",
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.85,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 42.5,
+        "tokens": 3800,
+        "tool_calls": 18,
+        "errors": 0
+      },
+      "expectations": [
+        {"text": "...", "passed": true, "evidence": "..."}
+      ],
+      "notes": [
+        "Used 2023 data, may be stale",
+        "Fell back to text overlay for non-fillable fields"
+      ]
+    }
+  ],
+
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {"mean": 0.85, "stddev": 0.05, "min": 0.80, "max": 0.90},
+      "time_seconds": {"mean": 45.0, "stddev": 12.0, "min": 32.0, "max": 58.0},
+      "tokens": {"mean": 3800, "stddev": 400, "min": 3200, "max": 4100}
+    },
+    "without_skill": {
+      "pass_rate": {"mean": 0.35, "stddev": 0.08, "min": 0.28, "max": 0.45},
+      "time_seconds": {"mean": 32.0, "stddev": 8.0, "min": 24.0, "max": 42.0},
+      "tokens": {"mean": 2100, "stddev": 300, "min": 1800, "max": 2500}
+    },
+    "delta": {
+      "pass_rate": "+0.50",
+      "time_seconds": "+13.0",
+      "tokens": "+1700"
+    }
+  },
+
+  "notes": [
+    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+    "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
+    "Without-skill runs consistently fail on table extraction expectations",
+    "Skill adds 13s average execution time but improves pass rate by 50%"
+  ]
+}
+```
+
+**Fields:**
+- `metadata`: Information about the benchmark run
+  - `skill_name`: Name of the skill
+  - `timestamp`: When the benchmark was run
+  - `evals_run`: List of eval names or IDs
+  - `runs_per_configuration`: Number of runs per config (e.g. 3)
+- `runs[]`: Individual run results
+  - `eval_id`: Numeric eval identifier
+  - `eval_name`: Human-readable eval name (used as section header in the viewer)
+  - `configuration`: Must be `"with_skill"` or `"without_skill"` (the viewer uses this exact string for grouping and color coding)
+  - `run_number`: Integer run number (1, 2, 3...)
+  - `result`: Nested object with `pass_rate`, `passed`, `total`, `time_seconds`, `tokens`, `errors`
+- `run_summary`: Statistical aggregates per configuration
+  - `with_skill` / `without_skill`: Each contains `pass_rate`, `time_seconds`, `tokens` objects with `mean` and `stddev` fields
+  - `delta`: Difference strings like `"+0.50"`, `"+13.0"`, `"+1700"`
+- `notes`: Freeform observations from the analyzer
+
+**Important:** The viewer reads these field names exactly. Using `config` instead of `configuration`, or putting `pass_rate` at the top level of a run instead of nested under `result`, will cause the viewer to show empty/zero values. Always reference this schema when generating benchmark.json manually.
+
+---
+
+## comparison.json
+
+Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## analysis.json
+
+Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": ["Minor: skipped optional logging step"]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods"
+  }
+}
+```

--- a/.agents/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/.agents/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Aggregate individual run results into benchmark summary statistics.
+
+Reads grading.json files from run directories and produces:
+- run_summary with mean, stddev, min, max for each metric
+- delta between with_skill and without_skill configurations
+
+Usage:
+    python aggregate_benchmark.py <benchmark_dir>
+
+Example:
+    python aggregate_benchmark.py benchmarks/2026-01-15T10-30-00/
+
+The script supports two directory layouts:
+
+    Workspace layout (from skill-creator iterations):
+    <benchmark_dir>/
+    └── eval-N/
+        ├── with_skill/
+        │   ├── run-1/grading.json
+        │   └── run-2/grading.json
+        └── without_skill/
+            ├── run-1/grading.json
+            └── run-2/grading.json
+
+    Legacy layout (with runs/ subdirectory):
+    <benchmark_dir>/
+    └── runs/
+        └── eval-N/
+            ├── with_skill/
+            │   └── run-1/grading.json
+            └── without_skill/
+                └── run-1/grading.json
+"""
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def calculate_stats(values: list[float]) -> dict:
+    """Calculate mean, stddev, min, max for a list of values."""
+    if not values:
+        return {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0}
+
+    n = len(values)
+    mean = sum(values) / n
+
+    if n > 1:
+        variance = sum((x - mean) ** 2 for x in values) / (n - 1)
+        stddev = math.sqrt(variance)
+    else:
+        stddev = 0.0
+
+    return {
+        "mean": round(mean, 4),
+        "stddev": round(stddev, 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4)
+    }
+
+
+def load_run_results(benchmark_dir: Path) -> dict:
+    """
+    Load all run results from a benchmark directory.
+
+    Returns dict keyed by config name (e.g. "with_skill"/"without_skill",
+    or "new_skill"/"old_skill"), each containing a list of run results.
+    """
+    # Support both layouts: eval dirs directly under benchmark_dir, or under runs/
+    runs_dir = benchmark_dir / "runs"
+    if runs_dir.exists():
+        search_dir = runs_dir
+    elif list(benchmark_dir.glob("eval-*")):
+        search_dir = benchmark_dir
+    else:
+        print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
+        return {}
+
+    results: dict[str, list] = {}
+
+    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
+        metadata_path = eval_dir / "eval_metadata.json"
+        if metadata_path.exists():
+            try:
+                with open(metadata_path) as mf:
+                    eval_id = json.load(mf).get("eval_id", eval_idx)
+            except (json.JSONDecodeError, OSError):
+                eval_id = eval_idx
+        else:
+            try:
+                eval_id = int(eval_dir.name.split("-")[1])
+            except ValueError:
+                eval_id = eval_idx
+
+        # Discover config directories dynamically rather than hardcoding names
+        for config_dir in sorted(eval_dir.iterdir()):
+            if not config_dir.is_dir():
+                continue
+            # Skip non-config directories (inputs, outputs, etc.)
+            if not list(config_dir.glob("run-*")):
+                continue
+            config = config_dir.name
+            if config not in results:
+                results[config] = []
+
+            for run_dir in sorted(config_dir.glob("run-*")):
+                run_number = int(run_dir.name.split("-")[1])
+                grading_file = run_dir / "grading.json"
+
+                if not grading_file.exists():
+                    print(f"Warning: grading.json not found in {run_dir}")
+                    continue
+
+                try:
+                    with open(grading_file) as f:
+                        grading = json.load(f)
+                except json.JSONDecodeError as e:
+                    print(f"Warning: Invalid JSON in {grading_file}: {e}")
+                    continue
+
+                # Extract metrics
+                result = {
+                    "eval_id": eval_id,
+                    "run_number": run_number,
+                    "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
+                    "passed": grading.get("summary", {}).get("passed", 0),
+                    "failed": grading.get("summary", {}).get("failed", 0),
+                    "total": grading.get("summary", {}).get("total", 0),
+                }
+
+                # Extract timing — check grading.json first, then sibling timing.json
+                timing = grading.get("timing", {})
+                result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
+                timing_file = run_dir / "timing.json"
+                if result["time_seconds"] == 0.0 and timing_file.exists():
+                    try:
+                        with open(timing_file) as tf:
+                            timing_data = json.load(tf)
+                        result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
+                        result["tokens"] = timing_data.get("total_tokens", 0)
+                    except json.JSONDecodeError:
+                        pass
+
+                # Extract metrics if available
+                metrics = grading.get("execution_metrics", {})
+                result["tool_calls"] = metrics.get("total_tool_calls", 0)
+                if not result.get("tokens"):
+                    result["tokens"] = metrics.get("output_chars", 0)
+                result["errors"] = metrics.get("errors_encountered", 0)
+
+                # Extract expectations — viewer requires fields: text, passed, evidence
+                raw_expectations = grading.get("expectations", [])
+                for exp in raw_expectations:
+                    if "text" not in exp or "passed" not in exp:
+                        print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
+                result["expectations"] = raw_expectations
+
+                # Extract notes from user_notes_summary
+                notes_summary = grading.get("user_notes_summary", {})
+                notes = []
+                notes.extend(notes_summary.get("uncertainties", []))
+                notes.extend(notes_summary.get("needs_review", []))
+                notes.extend(notes_summary.get("workarounds", []))
+                result["notes"] = notes
+
+                results[config].append(result)
+
+    return results
+
+
+def aggregate_results(results: dict) -> dict:
+    """
+    Aggregate run results into summary statistics.
+
+    Returns run_summary with stats for each configuration and delta.
+    """
+    run_summary = {}
+    configs = list(results.keys())
+
+    for config in configs:
+        runs = results.get(config, [])
+
+        if not runs:
+            run_summary[config] = {
+                "pass_rate": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "time_seconds": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "tokens": {"mean": 0, "stddev": 0, "min": 0, "max": 0}
+            }
+            continue
+
+        pass_rates = [r["pass_rate"] for r in runs]
+        times = [r["time_seconds"] for r in runs]
+        tokens = [r.get("tokens", 0) for r in runs]
+
+        run_summary[config] = {
+            "pass_rate": calculate_stats(pass_rates),
+            "time_seconds": calculate_stats(times),
+            "tokens": calculate_stats(tokens)
+        }
+
+    # Calculate delta between the first two configs (if two exist)
+    if len(configs) >= 2:
+        primary = run_summary.get(configs[0], {})
+        baseline = run_summary.get(configs[1], {})
+    else:
+        primary = run_summary.get(configs[0], {}) if configs else {}
+        baseline = {}
+
+    delta_pass_rate = primary.get("pass_rate", {}).get("mean", 0) - baseline.get("pass_rate", {}).get("mean", 0)
+    delta_time = primary.get("time_seconds", {}).get("mean", 0) - baseline.get("time_seconds", {}).get("mean", 0)
+    delta_tokens = primary.get("tokens", {}).get("mean", 0) - baseline.get("tokens", {}).get("mean", 0)
+
+    run_summary["delta"] = {
+        "pass_rate": f"{delta_pass_rate:+.2f}",
+        "time_seconds": f"{delta_time:+.1f}",
+        "tokens": f"{delta_tokens:+.0f}"
+    }
+
+    return run_summary
+
+
+def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: str = "") -> dict:
+    """
+    Generate complete benchmark.json from run results.
+    """
+    results = load_run_results(benchmark_dir)
+    run_summary = aggregate_results(results)
+
+    # Build runs array for benchmark.json
+    runs = []
+    for config in results:
+        for result in results[config]:
+            runs.append({
+                "eval_id": result["eval_id"],
+                "configuration": config,
+                "run_number": result["run_number"],
+                "result": {
+                    "pass_rate": result["pass_rate"],
+                    "passed": result["passed"],
+                    "failed": result["failed"],
+                    "total": result["total"],
+                    "time_seconds": result["time_seconds"],
+                    "tokens": result.get("tokens", 0),
+                    "tool_calls": result.get("tool_calls", 0),
+                    "errors": result.get("errors", 0)
+                },
+                "expectations": result["expectations"],
+                "notes": result["notes"]
+            })
+
+    # Determine eval IDs from results
+    eval_ids = sorted(set(
+        r["eval_id"]
+        for config in results.values()
+        for r in config
+    ))
+
+    benchmark = {
+        "metadata": {
+            "skill_name": skill_name or "<skill-name>",
+            "skill_path": skill_path or "<path/to/skill>",
+            "executor_model": "<model-name>",
+            "analyzer_model": "<model-name>",
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "evals_run": eval_ids,
+            "runs_per_configuration": 3
+        },
+        "runs": runs,
+        "run_summary": run_summary,
+        "notes": []  # To be filled by analyzer
+    }
+
+    return benchmark
+
+
+def generate_markdown(benchmark: dict) -> str:
+    """Generate human-readable benchmark.md from benchmark data."""
+    metadata = benchmark["metadata"]
+    run_summary = benchmark["run_summary"]
+
+    # Determine config names (excluding "delta")
+    configs = [k for k in run_summary if k != "delta"]
+    config_a = configs[0] if len(configs) >= 1 else "config_a"
+    config_b = configs[1] if len(configs) >= 2 else "config_b"
+    label_a = config_a.replace("_", " ").title()
+    label_b = config_b.replace("_", " ").title()
+
+    lines = [
+        f"# Skill Benchmark: {metadata['skill_name']}",
+        "",
+        f"**Model**: {metadata['executor_model']}",
+        f"**Date**: {metadata['timestamp']}",
+        f"**Evals**: {', '.join(map(str, metadata['evals_run']))} ({metadata['runs_per_configuration']} runs each per configuration)",
+        "",
+        "## Summary",
+        "",
+        f"| Metric | {label_a} | {label_b} | Delta |",
+        "|--------|------------|---------------|-------|",
+    ]
+
+    a_summary = run_summary.get(config_a, {})
+    b_summary = run_summary.get(config_b, {})
+    delta = run_summary.get("delta", {})
+
+    # Format pass rate
+    a_pr = a_summary.get("pass_rate", {})
+    b_pr = b_summary.get("pass_rate", {})
+    lines.append(f"| Pass Rate | {a_pr.get('mean', 0)*100:.0f}% ± {a_pr.get('stddev', 0)*100:.0f}% | {b_pr.get('mean', 0)*100:.0f}% ± {b_pr.get('stddev', 0)*100:.0f}% | {delta.get('pass_rate', '—')} |")
+
+    # Format time
+    a_time = a_summary.get("time_seconds", {})
+    b_time = b_summary.get("time_seconds", {})
+    lines.append(f"| Time | {a_time.get('mean', 0):.1f}s ± {a_time.get('stddev', 0):.1f}s | {b_time.get('mean', 0):.1f}s ± {b_time.get('stddev', 0):.1f}s | {delta.get('time_seconds', '—')}s |")
+
+    # Format tokens
+    a_tokens = a_summary.get("tokens", {})
+    b_tokens = b_summary.get("tokens", {})
+    lines.append(f"| Tokens | {a_tokens.get('mean', 0):.0f} ± {a_tokens.get('stddev', 0):.0f} | {b_tokens.get('mean', 0):.0f} ± {b_tokens.get('stddev', 0):.0f} | {delta.get('tokens', '—')} |")
+
+    # Notes section
+    if benchmark.get("notes"):
+        lines.extend([
+            "",
+            "## Notes",
+            ""
+        ])
+        for note in benchmark["notes"]:
+            lines.append(f"- {note}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate benchmark run results into summary statistics"
+    )
+    parser.add_argument(
+        "benchmark_dir",
+        type=Path,
+        help="Path to the benchmark directory"
+    )
+    parser.add_argument(
+        "--skill-name",
+        default="",
+        help="Name of the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--skill-path",
+        default="",
+        help="Path to the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        help="Output path for benchmark.json (default: <benchmark_dir>/benchmark.json)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.benchmark_dir.exists():
+        print(f"Directory not found: {args.benchmark_dir}")
+        sys.exit(1)
+
+    # Generate benchmark
+    benchmark = generate_benchmark(args.benchmark_dir, args.skill_name, args.skill_path)
+
+    # Determine output paths
+    output_json = args.output or (args.benchmark_dir / "benchmark.json")
+    output_md = output_json.with_suffix(".md")
+
+    # Write benchmark.json
+    with open(output_json, "w") as f:
+        json.dump(benchmark, f, indent=2)
+    print(f"Generated: {output_json}")
+
+    # Write benchmark.md
+    markdown = generate_markdown(benchmark)
+    with open(output_md, "w") as f:
+        f.write(markdown)
+    print(f"Generated: {output_md}")
+
+    # Print summary
+    run_summary = benchmark["run_summary"]
+    configs = [k for k in run_summary if k != "delta"]
+    delta = run_summary.get("delta", {})
+
+    print(f"\nSummary:")
+    for config in configs:
+        pr = run_summary[config]["pass_rate"]["mean"]
+        label = config.replace("_", " ").title()
+        print(f"  {label}: {pr*100:.1f}% pass rate")
+    print(f"  Delta:         {delta.get('pass_rate', '—')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/generate_report.py
+++ b/.agents/skills/skill-creator/scripts/generate_report.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate an HTML report from run_loop.py output.
+
+Takes the JSON output from run_loop.py and generates a visual HTML report
+showing each description attempt with check/x for each test case.
+Distinguishes between train and test queries.
+"""
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+
+
+def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
+    """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
+    history = data.get("history", [])
+    holdout = data.get("holdout", 0)
+    title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
+
+    # Get all unique queries from train and test sets, with should_trigger info
+    train_queries: list[dict] = []
+    test_queries: list[dict] = []
+    if history:
+        for r in history[0].get("train_results", history[0].get("results", [])):
+            train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+        if history[0].get("test_results"):
+            for r in history[0].get("test_results", []):
+                test_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+
+    refresh_tag = '    <meta http-equiv="refresh" content="5">\n' if auto_refresh else ""
+
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+""" + refresh_tag + """    <title>""" + title_prefix + """Skill Description Optimization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Lora', Georgia, serif;
+            max-width: 100%;
+            margin: 0 auto;
+            padding: 20px;
+            background: #faf9f5;
+            color: #141413;
+        }
+        h1 { font-family: 'Poppins', sans-serif; color: #141413; }
+        .explainer {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+            color: #b0aea5;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .summary {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+        }
+        .summary p { margin: 5px 0; }
+        .best { color: #788c5d; font-weight: bold; }
+        .table-container {
+            overflow-x: auto;
+            width: 100%;
+        }
+        table {
+            border-collapse: collapse;
+            background: white;
+            border: 1px solid #e8e6dc;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 100%;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e8e6dc;
+            white-space: normal;
+            word-wrap: break-word;
+        }
+        th {
+            font-family: 'Poppins', sans-serif;
+            background: #141413;
+            color: #faf9f5;
+            font-weight: 500;
+        }
+        th.test-col {
+            background: #6a9bcc;
+        }
+        th.query-col { min-width: 200px; }
+        td.description {
+            font-family: monospace;
+            font-size: 11px;
+            word-wrap: break-word;
+            max-width: 400px;
+        }
+        td.result {
+            text-align: center;
+            font-size: 16px;
+            min-width: 40px;
+        }
+        td.test-result {
+            background: #f0f6fc;
+        }
+        .pass { color: #788c5d; }
+        .fail { color: #c44; }
+        .rate {
+            font-size: 9px;
+            color: #b0aea5;
+            display: block;
+        }
+        tr:hover { background: #faf9f5; }
+        .score {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 11px;
+        }
+        .score-good { background: #eef2e8; color: #788c5d; }
+        .score-ok { background: #fef3c7; color: #d97706; }
+        .score-bad { background: #fceaea; color: #c44; }
+        .train-label { color: #b0aea5; font-size: 10px; }
+        .test-label { color: #6a9bcc; font-size: 10px; font-weight: bold; }
+        .best-row { background: #f5f8f2; }
+        th.positive-col { border-bottom: 3px solid #788c5d; }
+        th.negative-col { border-bottom: 3px solid #c44; }
+        th.test-col.positive-col { border-bottom: 3px solid #788c5d; }
+        th.test-col.negative-col { border-bottom: 3px solid #c44; }
+        .legend { font-family: 'Poppins', sans-serif; display: flex; gap: 20px; margin-bottom: 10px; font-size: 13px; align-items: center; }
+        .legend-item { display: flex; align-items: center; gap: 6px; }
+        .legend-swatch { width: 16px; height: 16px; border-radius: 3px; display: inline-block; }
+        .swatch-positive { background: #141413; border-bottom: 3px solid #788c5d; }
+        .swatch-negative { background: #141413; border-bottom: 3px solid #c44; }
+        .swatch-test { background: #6a9bcc; }
+        .swatch-train { background: #141413; }
+    </style>
+</head>
+<body>
+    <h1>""" + title_prefix + """Skill Description Optimization</h1>
+    <div class="explainer">
+        <strong>Optimizing your skill's description.</strong> This page updates automatically as Claude tests different versions of your skill's description. Each row is an iteration — a new description attempt. The columns show test queries: green checkmarks mean the skill triggered correctly (or correctly didn't trigger), red crosses mean it got it wrong. The "Train" score shows performance on queries used to improve the description; the "Test" score shows performance on held-out queries the optimizer hasn't seen. When it's done, Claude will apply the best-performing description to your skill.
+    </div>
+"""]
+
+    # Summary section
+    best_test_score = data.get('best_test_score')
+    best_train_score = data.get('best_train_score')
+    html_parts.append(f"""
+    <div class="summary">
+        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
+        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
+        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+    </div>
+""")
+
+    # Legend
+    html_parts.append("""
+    <div class="legend">
+        <span style="font-weight:600">Query columns:</span>
+        <span class="legend-item"><span class="legend-swatch swatch-positive"></span> Should trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-negative"></span> Should NOT trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-train"></span> Train</span>
+        <span class="legend-item"><span class="legend-swatch swatch-test"></span> Test</span>
+    </div>
+""")
+
+    # Table header
+    html_parts.append("""
+    <div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="query-col">Description</th>
+""")
+
+    # Add column headers for train queries
+    for qinfo in train_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="{polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    # Add column headers for test queries (different color)
+    for qinfo in test_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="test-col {polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    html_parts.append("""            </tr>
+        </thead>
+        <tbody>
+""")
+
+    # Find best iteration for highlighting
+    if test_queries:
+        best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
+    else:
+        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+
+    # Add rows for each iteration
+    for h in history:
+        iteration = h.get("iteration", "?")
+        train_passed = h.get("train_passed", h.get("passed", 0))
+        train_total = h.get("train_total", h.get("total", 0))
+        test_passed = h.get("test_passed")
+        test_total = h.get("test_total")
+        description = h.get("description", "")
+        train_results = h.get("train_results", h.get("results", []))
+        test_results = h.get("test_results", [])
+
+        # Create lookups for results by query
+        train_by_query = {r["query"]: r for r in train_results}
+        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+
+        # Compute aggregate correct/total runs across all retries
+        def aggregate_runs(results: list[dict]) -> tuple[int, int]:
+            correct = 0
+            total = 0
+            for r in results:
+                runs = r.get("runs", 0)
+                triggers = r.get("triggers", 0)
+                total += runs
+                if r.get("should_trigger", True):
+                    correct += triggers
+                else:
+                    correct += runs - triggers
+            return correct, total
+
+        train_correct, train_runs = aggregate_runs(train_results)
+        test_correct, test_runs = aggregate_runs(test_results)
+
+        # Determine score classes
+        def score_class(correct: int, total: int) -> str:
+            if total > 0:
+                ratio = correct / total
+                if ratio >= 0.8:
+                    return "score-good"
+                elif ratio >= 0.5:
+                    return "score-ok"
+            return "score-bad"
+
+        train_class = score_class(train_correct, train_runs)
+        test_class = score_class(test_correct, test_runs)
+
+        row_class = "best-row" if iteration == best_iter else ""
+
+        html_parts.append(f"""            <tr class="{row_class}">
+                <td>{iteration}</td>
+                <td><span class="score {train_class}">{train_correct}/{train_runs}</span></td>
+                <td><span class="score {test_class}">{test_correct}/{test_runs}</span></td>
+                <td class="description">{html.escape(description)}</td>
+""")
+
+        # Add result for each train query
+        for qinfo in train_queries:
+            r = train_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        # Add result for each test query (with different background)
+        for qinfo in test_queries:
+            r = test_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result test-result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        html_parts.append("            </tr>\n")
+
+    html_parts.append("""        </tbody>
+    </table>
+    </div>
+""")
+
+    html_parts.append("""
+</body>
+</html>
+""")
+
+    return "".join(html_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML report from run_loop output")
+    parser.add_argument("input", help="Path to JSON output from run_loop.py (or - for stdin)")
+    parser.add_argument("-o", "--output", default=None, help="Output HTML file (default: stdout)")
+    parser.add_argument("--skill-name", default="", help="Skill name to include in the report title")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(args.input).read_text())
+
+    html_output = generate_html(data, skill_name=args.skill_name)
+
+    if args.output:
+        Path(args.output).write_text(html_output)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(html_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/improve_description.py
+++ b/.agents/skills/skill-creator/scripts/improve_description.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Improve a skill description based on eval results.
+
+Takes eval results (from run_eval.py) and generates an improved description
+by calling `claude -p` as a subprocess (same auth pattern as run_eval.py —
+uses the session's Claude Code auth, no separate ANTHROPIC_API_KEY needed).
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
+    """Run `claude -p` with the prompt on stdin and return the text response.
+
+    Prompt goes over stdin (not argv) because it embeds the full SKILL.md
+    body and can easily exceed comfortable argv length.
+    """
+    cmd = ["claude", "-p", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+
+    # Remove CLAUDECODE env var to allow nesting claude -p inside a
+    # Claude Code session. The guard is for interactive terminal conflicts;
+    # programmatic subprocess usage is safe. Same pattern as run_eval.py.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def improve_description(
+    skill_name: str,
+    skill_content: str,
+    current_description: str,
+    eval_results: dict,
+    history: list[dict],
+    model: str,
+    test_results: dict | None = None,
+    log_dir: Path | None = None,
+    iteration: int | None = None,
+) -> str:
+    """Call Claude to improve the description based on eval results."""
+    failed_triggers = [
+        r for r in eval_results["results"]
+        if r["should_trigger"] and not r["pass"]
+    ]
+    false_triggers = [
+        r for r in eval_results["results"]
+        if not r["should_trigger"] and not r["pass"]
+    ]
+
+    # Build scores summary
+    train_score = f"{eval_results['summary']['passed']}/{eval_results['summary']['total']}"
+    if test_results:
+        test_score = f"{test_results['summary']['passed']}/{test_results['summary']['total']}"
+        scores_summary = f"Train: {train_score}, Test: {test_score}"
+    else:
+        scores_summary = f"Train: {train_score}"
+
+    prompt = f"""You are optimizing a skill description for a Claude Code skill called "{skill_name}". A "skill" is sort of like a prompt, but with progressive disclosure -- there's a title and description that Claude sees when deciding whether to use the skill, and then if it does use the skill, it reads the .md file which has lots more details and potentially links to other resources in the skill folder like helper files and scripts and additional documentation or examples.
+
+The description appears in Claude's "available_skills" list. When a user sends a query, Claude decides whether to invoke the skill based solely on the title and on this description. Your goal is to write a description that triggers for relevant queries, and doesn't trigger for irrelevant ones.
+
+Here's the current description:
+<current_description>
+"{current_description}"
+</current_description>
+
+Current scores ({scores_summary}):
+<scores_summary>
+"""
+    if failed_triggers:
+        prompt += "FAILED TO TRIGGER (should have triggered but didn't):\n"
+        for r in failed_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if false_triggers:
+        prompt += "FALSE TRIGGERS (triggered but shouldn't have):\n"
+        for r in false_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if history:
+        prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
+        for h in history:
+            train_s = f"{h.get('train_passed', h.get('passed', 0))}/{h.get('train_total', h.get('total', 0))}"
+            test_s = f"{h.get('test_passed', '?')}/{h.get('test_total', '?')}" if h.get('test_passed') is not None else None
+            score_str = f"train={train_s}" + (f", test={test_s}" if test_s else "")
+            prompt += f'<attempt {score_str}>\n'
+            prompt += f'Description: "{h["description"]}"\n'
+            if "results" in h:
+                prompt += "Train results:\n"
+                for r in h["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
+            if h.get("note"):
+                prompt += f'Note: {h["note"]}\n'
+            prompt += "</attempt>\n\n"
+
+    prompt += f"""</scores_summary>
+
+Skill content (for context on what the skill does):
+<skill_content>
+{skill_content}
+</skill_content>
+
+Based on the failures, write a new and improved description that is more likely to trigger correctly. When I say "based on the failures", it's a bit of a tricky line to walk because we don't want to overfit to the specific cases you're seeing. So what I DON'T want you to do is produce an ever-expanding list of specific queries that this skill should or shouldn't trigger for. Instead, try to generalize from the failures to broader categories of user intent and situations where this skill would be useful or not useful. The reason for this is twofold:
+
+1. Avoid overfitting
+2. The list might get loooong and it's injected into ALL queries and there might be a lot of skills, so we don't want to blow too much space on any given description.
+
+Concretely, your description should not be more than about 100-200 words, even if that comes at the cost of accuracy. There is a hard limit of 1024 characters — descriptions over that will be truncated, so stay comfortably under it.
+
+Here are some tips that we've found to work well in writing these descriptions:
+- The skill should be phrased in the imperative -- "Use this skill for" rather than "this skill does"
+- The skill description should focus on the user's intent, what they are trying to achieve, vs. the implementation details of how the skill works.
+- The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
+- If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
+
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+
+Please respond with only the new description text in <new_description> tags, nothing else."""
+
+    text = _call_claude(prompt, model)
+
+    match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
+    description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
+
+    transcript: dict = {
+        "iteration": iteration,
+        "prompt": prompt,
+        "response": text,
+        "parsed_description": description,
+        "char_count": len(description),
+        "over_limit": len(description) > 1024,
+    }
+
+    # Safety net: the prompt already states the 1024-char hard limit, but if
+    # the model blew past it anyway, make one fresh single-turn call that
+    # quotes the too-long version and asks for a shorter rewrite. (The old
+    # SDK path did this as a true multi-turn; `claude -p` is one-shot, so we
+    # inline the prior output into the new prompt instead.)
+    if len(description) > 1024:
+        shorten_prompt = (
+            f"{prompt}\n\n"
+            f"---\n\n"
+            f"A previous attempt produced this description, which at "
+            f"{len(description)} characters is over the 1024-character hard limit:\n\n"
+            f'"{description}"\n\n'
+            f"Rewrite it to be under 1024 characters while keeping the most "
+            f"important trigger words and intent coverage. Respond with only "
+            f"the new description in <new_description> tags."
+        )
+        shorten_text = _call_claude(shorten_prompt, model)
+        match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
+        shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
+
+        transcript["rewrite_prompt"] = shorten_prompt
+        transcript["rewrite_response"] = shorten_text
+        transcript["rewrite_description"] = shortened
+        transcript["rewrite_char_count"] = len(shortened)
+        description = shortened
+
+    transcript["final_description"] = description
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
+        log_file.write_text(json.dumps(transcript, indent=2))
+
+    return description
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Improve a skill description based on eval results")
+    parser.add_argument("--eval-results", required=True, help="Path to eval results JSON (from run_eval.py)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--history", default=None, help="Path to history JSON (previous attempts)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print thinking to stderr")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path)
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    eval_results = json.loads(Path(args.eval_results).read_text())
+    history = []
+    if args.history:
+        history = json.loads(Path(args.history).read_text())
+
+    name, _, content = parse_skill_md(skill_path)
+    current_description = eval_results["description"]
+
+    if args.verbose:
+        print(f"Current: {current_description}", file=sys.stderr)
+        print(f"Score: {eval_results['summary']['passed']}/{eval_results['summary']['total']}", file=sys.stderr)
+
+    new_description = improve_description(
+        skill_name=name,
+        skill_content=content,
+        current_description=current_description,
+        eval_results=eval_results,
+        history=history,
+        model=args.model,
+    )
+
+    if args.verbose:
+        print(f"Improved: {new_description}", file=sys.stderr)
+
+    # Output as JSON with both the new description and updated history
+    output = {
+        "description": new_description,
+        "history": history + [{
+            "description": current_description,
+            "passed": eval_results["summary"]["passed"],
+            "failed": eval_results["summary"]["failed"],
+            "total": eval_results["summary"]["total"],
+            "results": eval_results["results"],
+        }],
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/package_skill.py
+++ b/.agents/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import fnmatch
+import sys
+import zipfile
+from pathlib import Path
+from scripts.quick_validate import validate_skill
+
+# Patterns to exclude when packaging skills.
+EXCLUDE_DIRS = {"__pycache__", "node_modules"}
+EXCLUDE_GLOBS = {"*.pyc"}
+EXCLUDE_FILES = {".DS_Store"}
+# Directories excluded only at the skill root (not when nested deeper).
+ROOT_EXCLUDE_DIRS = {"evals"}
+
+
+def should_exclude(rel_path: Path) -> bool:
+    """Check if a path should be excluded from packaging."""
+    parts = rel_path.parts
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    # rel_path is relative to skill_path.parent, so parts[0] is the skill
+    # folder name and parts[1] (if present) is the first subdir.
+    if len(parts) > 1 and parts[1] in ROOT_EXCLUDE_DIRS:
+        return True
+    name = rel_path.name
+    if name in EXCLUDE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, pat) for pat in EXCLUDE_GLOBS)
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory, excluding build artifacts
+            for file_path in skill_path.rglob('*'):
+                if not file_path.is_file():
+                    continue
+                arcname = file_path.relative_to(skill_path.parent)
+                if should_exclude(arcname):
+                    print(f"  Skipped: {arcname}")
+                    continue
+                zipf.write(file_path, arcname)
+                print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/quick_validate.py
+++ b/.agents/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.agents/skills/skill-creator/scripts/run_eval.py
+++ b/.agents/skills/skill-creator/scripts/run_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for a skill description.
+
+Tests whether a skill's description causes Claude to trigger (read the skill)
+for a set of queries. Outputs results as JSON.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/.
+
+    Mimics how Claude Code discovers its project root, so the command file
+    we create ends up where claude -p will look for it.
+    """
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Creates a command file in .claude/commands/ so it appears in Claude's
+    available_skills list, then runs `claude -p` with the raw query.
+    Uses --include-partial-messages to detect triggering early from
+    stream events (content_block_start) rather than waiting for the
+    full assistant message, which only arrives after tool execution.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        # Use YAML block scalar to avoid breaking on quotes in description
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        # Remove CLAUDECODE env var to allow nesting claude -p inside a
+        # Claude Code session. The guard is for interactive terminal conflicts;
+        # programmatic subprocess usage is safe.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        # Track state for stream event detection
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Early detection via stream events
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    # Fallback: full assistant message
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            # Clean up process on any exit path (return, exception, timeout)
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill description")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override description to test")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/run_loop.py
+++ b/.agents/skills/skill-creator/scripts/run_loop.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Run the eval + improve loop until all pass or max iterations reached.
+
+Combines run_eval.py and improve_description.py in a loop, tracking history
+and returning the best description found. Supports train/test split to prevent
+overfitting.
+"""
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+import time
+import webbrowser
+from pathlib import Path
+
+from scripts.generate_report import generate_html
+from scripts.improve_description import improve_description
+from scripts.run_eval import find_project_root, run_eval
+from scripts.utils import parse_skill_md
+
+
+def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
+    """Split eval set into train and test sets, stratified by should_trigger."""
+    random.seed(seed)
+
+    # Separate by should_trigger
+    trigger = [e for e in eval_set if e["should_trigger"]]
+    no_trigger = [e for e in eval_set if not e["should_trigger"]]
+
+    # Shuffle each group
+    random.shuffle(trigger)
+    random.shuffle(no_trigger)
+
+    # Calculate split points
+    n_trigger_test = max(1, int(len(trigger) * holdout))
+    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+
+    # Split
+    test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
+    train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
+
+    return train_set, test_set
+
+
+def run_loop(
+    eval_set: list[dict],
+    skill_path: Path,
+    description_override: str | None,
+    num_workers: int,
+    timeout: int,
+    max_iterations: int,
+    runs_per_query: int,
+    trigger_threshold: float,
+    holdout: float,
+    model: str,
+    verbose: bool,
+    live_report_path: Path | None = None,
+    log_dir: Path | None = None,
+) -> dict:
+    """Run the eval + improvement loop."""
+    project_root = find_project_root()
+    name, original_description, content = parse_skill_md(skill_path)
+    current_description = description_override or original_description
+
+    # Split into train/test if holdout > 0
+    if holdout > 0:
+        train_set, test_set = split_eval_set(eval_set, holdout)
+        if verbose:
+            print(f"Split: {len(train_set)} train, {len(test_set)} test (holdout={holdout})", file=sys.stderr)
+    else:
+        train_set = eval_set
+        test_set = []
+
+    history = []
+    exit_reason = "unknown"
+
+    for iteration in range(1, max_iterations + 1):
+        if verbose:
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+            print(f"Description: {current_description}", file=sys.stderr)
+            print(f"{'='*60}", file=sys.stderr)
+
+        # Evaluate train + test together in one batch for parallelism
+        all_queries = train_set + test_set
+        t0 = time.time()
+        all_results = run_eval(
+            eval_set=all_queries,
+            skill_name=name,
+            description=current_description,
+            num_workers=num_workers,
+            timeout=timeout,
+            project_root=project_root,
+            runs_per_query=runs_per_query,
+            trigger_threshold=trigger_threshold,
+            model=model,
+        )
+        eval_elapsed = time.time() - t0
+
+        # Split results back into train/test by matching queries
+        train_queries_set = {q["query"] for q in train_set}
+        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+        train_passed = sum(1 for r in train_result_list if r["pass"])
+        train_total = len(train_result_list)
+        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+        train_results = {"results": train_result_list, "summary": train_summary}
+
+        if test_set:
+            test_passed = sum(1 for r in test_result_list if r["pass"])
+            test_total = len(test_result_list)
+            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+            test_results = {"results": test_result_list, "summary": test_summary}
+        else:
+            test_results = None
+            test_summary = None
+
+        history.append({
+            "iteration": iteration,
+            "description": current_description,
+            "train_passed": train_summary["passed"],
+            "train_failed": train_summary["failed"],
+            "train_total": train_summary["total"],
+            "train_results": train_results["results"],
+            "test_passed": test_summary["passed"] if test_summary else None,
+            "test_failed": test_summary["failed"] if test_summary else None,
+            "test_total": test_summary["total"] if test_summary else None,
+            "test_results": test_results["results"] if test_results else None,
+            # For backward compat with report generator
+            "passed": train_summary["passed"],
+            "failed": train_summary["failed"],
+            "total": train_summary["total"],
+            "results": train_results["results"],
+        })
+
+        # Write live report if path provided
+        if live_report_path:
+            partial_output = {
+                "original_description": original_description,
+                "best_description": current_description,
+                "best_score": "in progress",
+                "iterations_run": len(history),
+                "holdout": holdout,
+                "train_size": len(train_set),
+                "test_size": len(test_set),
+                "history": history,
+            }
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+
+        if verbose:
+            def print_eval_stats(label, results, elapsed):
+                pos = [r for r in results if r["should_trigger"]]
+                neg = [r for r in results if not r["should_trigger"]]
+                tp = sum(r["triggers"] for r in pos)
+                pos_runs = sum(r["runs"] for r in pos)
+                fn = pos_runs - tp
+                fp = sum(r["triggers"] for r in neg)
+                neg_runs = sum(r["runs"] for r in neg)
+                tn = neg_runs - fp
+                total = tp + tn + fp + fn
+                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                accuracy = (tp + tn) / total if total > 0 else 0.0
+                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                for r in results:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
+
+            print_eval_stats("Train", train_results["results"], eval_elapsed)
+            if test_summary:
+                print_eval_stats("Test ", test_results["results"], 0)
+
+        if train_summary["failed"] == 0:
+            exit_reason = f"all_passed (iteration {iteration})"
+            if verbose:
+                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+            break
+
+        if iteration == max_iterations:
+            exit_reason = f"max_iterations ({max_iterations})"
+            if verbose:
+                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+            break
+
+        # Improve the description based on train results
+        if verbose:
+            print(f"\nImproving description...", file=sys.stderr)
+
+        t0 = time.time()
+        # Strip test scores from history so improvement model can't see them
+        blinded_history = [
+            {k: v for k, v in h.items() if not k.startswith("test_")}
+            for h in history
+        ]
+        new_description = improve_description(
+            skill_name=name,
+            skill_content=content,
+            current_description=current_description,
+            eval_results=train_results,
+            history=blinded_history,
+            model=model,
+            log_dir=log_dir,
+            iteration=iteration,
+        )
+        improve_elapsed = time.time() - t0
+
+        if verbose:
+            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+        current_description = new_description
+
+    # Find the best iteration by TEST score (or train if no test set)
+    if test_set:
+        best = max(history, key=lambda h: h["test_passed"] or 0)
+        best_score = f"{best['test_passed']}/{best['test_total']}"
+    else:
+        best = max(history, key=lambda h: h["train_passed"])
+        best_score = f"{best['train_passed']}/{best['train_total']}"
+
+    if verbose:
+        print(f"\nExit reason: {exit_reason}", file=sys.stderr)
+        print(f"Best score: {best_score} (iteration {best['iteration']})", file=sys.stderr)
+
+    return {
+        "exit_reason": exit_reason,
+        "original_description": original_description,
+        "best_description": best["description"],
+        "best_score": best_score,
+        "best_train_score": f"{best['train_passed']}/{best['train_total']}",
+        "best_test_score": f"{best['test_passed']}/{best['test_total']}" if test_set else None,
+        "final_description": current_description,
+        "iterations_run": len(history),
+        "holdout": holdout,
+        "train_size": len(train_set),
+        "test_size": len(test_set),
+        "history": history,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run eval + improve loop")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override starting description")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
+    parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, _, _ = parse_skill_md(skill_path)
+
+    # Set up live report path
+    if args.report != "none":
+        if args.report == "auto":
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            live_report_path = Path(tempfile.gettempdir()) / f"skill_description_report_{skill_path.name}_{timestamp}.html"
+        else:
+            live_report_path = Path(args.report)
+        # Open the report immediately so the user can watch
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        webbrowser.open(str(live_report_path))
+    else:
+        live_report_path = None
+
+    # Determine output directory (create before run_loop so logs can be written)
+    if args.results_dir:
+        timestamp = time.strftime("%Y-%m-%d_%H%M%S")
+        results_dir = Path(args.results_dir) / timestamp
+        results_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        results_dir = None
+
+    log_dir = results_dir / "logs" if results_dir else None
+
+    output = run_loop(
+        eval_set=eval_set,
+        skill_path=skill_path,
+        description_override=args.description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        max_iterations=args.max_iterations,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        holdout=args.holdout,
+        model=args.model,
+        verbose=args.verbose,
+        live_report_path=live_report_path,
+        log_dir=log_dir,
+    )
+
+    # Save JSON output
+    json_output = json.dumps(output, indent=2)
+    print(json_output)
+    if results_dir:
+        (results_dir / "results.json").write_text(json_output)
+
+    # Write final HTML report (without auto-refresh)
+    if live_report_path:
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        print(f"\nReport: {live_report_path}", file=sys.stderr)
+
+    if results_dir and live_report_path:
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+
+    if results_dir:
+        print(f"Results saved to: {results_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/utils.py
+++ b/.agents/skills/skill-creator/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ two-line snippet is enough.
   [`docs/explanation/architecture-from-example.md`](docs/explanation/architecture-from-example.md)
 - Bootstrap the adapter-specific SQLAlchemy path:
   [`docs/how-to/bootstrap-sqlalchemy-app.md`](docs/how-to/bootstrap-sqlalchemy-app.md)
+- Migrate existing apps to the scoped execution model:
+  [`docs/how-to/migrate-to-0.3.0-scoped-execution.md`](docs/how-to/migrate-to-0.3.0-scoped-execution.md)
 - Learn the canonical testing workflow:
   [`docs/how-to/test-use-cases.md`](docs/how-to/test-use-cases.md)
 - Check the guardrails before copying imports:
@@ -57,6 +59,8 @@ The documented path is intentionally narrow.
   `hexagonal.entrypoints`
 - Reach for `hexagonal.integrations.sqlalchemy` when you need the reusable
   SQLAlchemy repository and unit-of-work utilities
+- Treat scoped execution as the default mental model: shared datastore and
+  mapper, fresh write/read scope per operation
 - Treat `hexagonal.entrypoints.sqlalchemy` as adapter-specific convenience, not
   the whole framework story
 - Do not treat `hexagonal.__init__` as the public integration surface; right now

--- a/docs/getting-started/first-app.md
+++ b/docs/getting-started/first-app.md
@@ -36,8 +36,9 @@ Read these files next:
 - `src/example/contacto/ports/drivens.py`
 - `src/example/contacto/ports/drivers.py`
 
-`drivens.py` defines the infrastructure the app needs: repositories and unit of
-work. `drivers.py` defines the application-facing contract.
+`drivens.py` defines the infrastructure the app needs: repositories, scope
+creation, and unit-of-work boundaries. `drivers.py` defines the
+application-facing contract.
 
 That separation matters because the application layer depends on interfaces, not
 database code.
@@ -144,6 +145,7 @@ The test bootstrap proves the intended flow:
 - run migrations
 - create the app through `exampleEntrypoint.get(env=...)`
 - wrap it with `exampleAPI`
+- let buses resolve handlers and repositories inside fresh scopes
 - call `register_topics()` before dispatching commands or publishing events
 
 That is the evidence-backed baseline for testing your own app.
@@ -153,9 +155,10 @@ That is the evidence-backed baseline for testing your own app.
 1. `README.md`
 2. `docs/explanation/architecture-from-example.md`
 3. `docs/how-to/bootstrap-sqlalchemy-app.md`
-4. `docs/how-to/test-use-cases.md`
-5. `docs/reference/supported-surface.md`
-6. `docs/reference/evidence-map.yaml`
+4. `docs/how-to/migrate-to-0.3.0-scoped-execution.md`
+5. `docs/how-to/test-use-cases.md`
+6. `docs/reference/supported-surface.md`
+7. `docs/reference/evidence-map.yaml`
 
 If you want repo-specific guidance after that, run the companion skill in
 `skills/python-hexagonal-usage/SKILL.md`.

--- a/docs/how-to/bootstrap-sqlalchemy-app.md
+++ b/docs/how-to/bootstrap-sqlalchemy-app.md
@@ -56,10 +56,10 @@ The SQLAlchemy-specific infrastructure lives in
 
 The important pattern is:
 
-- accept a mapper and connection manager
-- create a unit of work
-- build the infrastructure needed by the bounded context
-- group those pieces into one object that satisfies the application ports
+- accept a mapper and datastore
+- expose factories that create fresh read and write scopes
+- build repositories and unit of work inside those scopes
+- group those factories into one object that satisfies the application ports
 
 Conceptually the shape looks like this:
 
@@ -70,12 +70,21 @@ from hexagonal.integrations.sqlalchemy import SQLAlchemyUnitOfWork
 
 class YourSQLAlchemyInfrastructure(InfrastructureGroup):
     def __init__(self, mapper, manager):
-        self._uow = SQLAlchemyUnitOfWork(connection_manager=manager)
-        self._context = YourContextInfrastructure(manager, mapper, self._uow)
-        super().__init__(self._context & self._uow)
+        self._mapper = mapper
+        self._datastore = datastore
+
+    def create_read_scope(self):
+        return SQLAlchemyConnectionContextManager(self._datastore)
+
+    def create_write_scope(self):
+        manager = self.create_read_scope()
+        repository = YourRepository(self._mapper, manager)
+        uow = SQLAlchemyUnitOfWork(repository, connection_manager=manager)
+        return YourWriteScope(uow=uow, repository=repository)
 ```
 
-Copy the role separation, not the example class names.
+Copy the role separation, not the example class names. In `0.3.0`, the thing to
+copy is scoped execution, not a singleton `uow` sitting in app state.
 
 ## Step 3: create the application from infrastructure
 
@@ -87,7 +96,7 @@ The example app creation happens in two layers:
 The bootstrap rule is boring on purpose:
 
 1. infrastructure verifies itself
-2. each focused app is created with the dependencies it needs
+2. each focused app is created with the infrastructure and scope providers it needs
 3. one top-level app groups the result
 
 If your bootstrap needs ten conditionals and half a framework container before
@@ -170,6 +179,17 @@ Do NOT do this:
 
 The supported boundary is documented in `docs/reference/supported-surface.md`.
 
+## Step 5.5: stop sharing live write objects
+
+If you already have an app on older versions, this is the rule that matters:
+
+- share datastore, mapper, and factories
+- do NOT share a live `UnitOfWork`
+- do NOT reuse repositories across parallel dispatches
+- register handlers through providers that resolve dependencies inside a scope
+
+That is the architectural shift in `0.3.0`.
+
 ## Step 6: verify bootstrap through the same path tests use
 
 The example tests do NOT instantiate random internals directly.
@@ -183,4 +203,5 @@ lying to you.
 
 1. `docs/how-to/test-use-cases.md`
 2. `docs/reference/supported-surface.md`
-3. `docs/reference/evidence-map.yaml`
+3. `docs/how-to/migrate-to-0.3.0-scoped-execution.md`
+4. `docs/reference/evidence-map.yaml`

--- a/docs/how-to/migrate-to-0.3.0-scoped-execution.md
+++ b/docs/how-to/migrate-to-0.3.0-scoped-execution.md
@@ -1,0 +1,185 @@
+# Migrate to 0.3.0 scoped execution
+
+This guide is for clients upgrading to `0.3.0`.
+
+The headline is simple:
+
+- shared infrastructure stays shared
+- live execution objects do not
+
+If your app already uses `exampleEntrypoint.get(env)` and `exampleAPI(app)` as
+the adoption model, the migration should be moderate.
+If you built directly against mutable internals, you have cleanup to do. That is
+not the library being mean; that is your coupling showing up.
+
+## What changed
+
+The library now treats execution through explicit scopes.
+
+- commands and events use fresh write scopes
+- queries use fresh read scopes
+- buses resolve handlers inside those scopes
+- repositories and `UnitOfWork` instances are scope-bound, not long-lived
+
+What is still safe to share:
+
+- datastore / engine
+- mapper and configuration
+- provider and factory objects
+
+What should stop being shared:
+
+- `UnitOfWork` instances used for active work
+- repositories that hold a live manager/connection boundary
+- handlers prebuilt with mutable write dependencies captured forever
+
+## If you are already on the documented path
+
+If your app looks like the example:
+
+- entrypoint chooses infrastructure from environment
+- infrastructure builds the app
+- callers use `exampleAPI(app)`-style wrappers
+
+then your public calling code should barely change.
+
+The main changes are in bootstrap and wiring.
+
+## Migration checklist
+
+### 1. Stop storing a live `uow` as shared app state
+
+Old mental model:
+
+```python
+uow = SQLAlchemyUnitOfWork(connection_manager=manager)
+handler = CrearContactoHandler(repo=repo, uow=uow)
+```
+
+New mental model:
+
+```python
+scope_runner = SQLAlchemyScopeRunner(create_write_scope, create_read_scope)
+command_bus.configure_scope_runtime(
+    write_scope_runner=scope_runner,
+    outbox_repository_getter=lambda scope: scope.outbox_repository,
+)
+```
+
+The point is not the exact API spelling. The point is that live write objects now
+come from scope factories.
+
+### 2. Build repositories inside the scope
+
+Old pattern:
+
+- build repositories once at bootstrap
+- reuse them for every command/event/query
+
+New pattern:
+
+- keep datastore and mapper shared
+- create repositories from the scope manager created for that operation
+
+Conceptually:
+
+```python
+def create_write_scope() -> YourWriteScope:
+    manager = create_read_scope()
+    contacto_repository = ContactoRepository(mapper, manager)
+    outbox_repository = SQLAlchemyOutboxRepository(mapper, manager)
+    uow = SQLAlchemyUnitOfWork(
+        contacto_repository,
+        outbox_repository,
+        connection_manager=manager,
+    )
+    return YourWriteScope(
+        uow=uow,
+        contacto_repository=contacto_repository,
+        outbox_repository=outbox_repository,
+    )
+```
+
+### 3. Register handler providers, not only prebuilt instances
+
+If you were registering long-lived handler instances that captured repositories
+or a mutable `uow`, migrate that wiring so the bus resolves handlers through the
+scope runtime.
+
+What changes conceptually:
+
+- before: handler already held write dependencies
+- after: handler uses dependencies tied to the active scope
+
+## Client impact by usage style
+
+### Low impact
+
+Your app:
+
+- boots through entrypoints
+- exposes a stable API facade
+- does not import `hexagonal.adapters.*` directly for new code
+
+What you likely change:
+
+- infrastructure wiring only
+
+### Medium impact
+
+Your app:
+
+- has custom bus bootstrap
+- manually assembles SQLAlchemy infrastructure
+
+What you likely change:
+
+- add read/write scope factories
+- configure buses with scope runtime
+- move repository creation into scopes
+
+### High impact
+
+Your app:
+
+- keeps one `uow` around forever
+- stores repositories as singleton collaborators
+- depends on compatibility helpers like `attach_repo()` as normal design
+
+What you likely change:
+
+- rewrite bootstrap and handler wiring to provider/factory-based execution
+
+## Compatibility notes
+
+These compatibility paths still exist, but treat them as bridges:
+
+- `uow`
+- `attach_repo()`
+- `attach_to_unit_of_work()`
+
+They are there to reduce migration pain, not to define the future architecture.
+
+## Recommended rollout plan for clients
+
+1. keep your public API facade stable
+2. migrate bootstrap to scope factories
+3. move repository creation into scopes
+4. configure command/event/query flows with scope runtime
+5. remove direct dependencies on long-lived mutable write objects
+
+## Evidence to copy from this repo
+
+- `src/example/app/adapters/drivens/repository/sqlalchemy.py`
+- `src/example/app/application/app.py`
+- `src/example/app/entrypoints/db/sqlalchemy.py`
+- `src/tests/test_parallel_safe_scopes.py`
+- `src/tests/test_parallel_dispatch_isolation.py`
+
+Use those files to copy the roles and flow, not the naming.
+
+## Follow-up reading
+
+1. `docs/how-to/bootstrap-sqlalchemy-app.md`
+2. `docs/reference/supported-surface.md`
+3. `docs/explanation/architecture-from-example.md`

--- a/docs/reference/supported-surface.md
+++ b/docs/reference/supported-surface.md
@@ -29,6 +29,19 @@ and the reusable repository/unit-of-work helpers are now promoted behind an
 explicit public namespace. Treat both as SQLAlchemy-only integration surfaces,
 not as the whole architecture.
 
+## Scoped execution rule
+
+Starting in `0.3.0`, the supported execution model is:
+
+- share datastore, mapper, and provider/factory objects
+- create a fresh write scope per command/event dispatch
+- create a fresh read scope per query/read operation
+- treat long-lived `uow` or repository instances as compatibility shims, not as
+  the preferred integration pattern
+
+If your app wiring still captures repositories or a mutable `uow` at bootstrap
+time, you are fighting the supported model.
+
 ### Internal or evidence-only
 
 - `hexagonal.__init__`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-hexagonal"
-version = "0.2.0"
+version = "0.3.0"
 description = "Framework to build hexagonal architecture applications in Python."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,22 @@ module-name = "hexagonal"
 select = ["I", "E", "F", "B"]
 fixable = ["I", "E", "F", "B"]
 
+[tool.mypy]
+mypy_path = ["src"]
+python_version = "3.12"
+strict = true
+namespace_packages = true
+explicit_package_bases = true
+show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = ["alembic", "alembic.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+disable_error_code = ["attr-defined", "no-untyped-call", "no-untyped-def", "var-annotated"]
+
 [dependency-groups]
 dev = [
     "alembic>=1.18.4",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "skills": {
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "computedHash": "645b891da1edbae76ab79c7b088d4e73397464f8396edaf773c0e01971ce75d6"
+    },
+    "modern-python": {
+      "source": "trailofbits/skills",
+      "sourceType": "github",
+      "computedHash": "cf3f5314887a7726b3a18be574dcb4c753e74ce5105d5496d1f18c802c9e4e77"
+    },
+    "ruff-linting": {
+      "source": "laurigates/claude-plugins",
+      "sourceType": "github",
+      "computedHash": "d1fb6d34d48a645bc5715f91dd5ba176aad87355147e965ad49cfd4a8744d9a7"
+    }
+  }
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -35,6 +35,11 @@
       "source": "laurigates/claude-plugins",
       "sourceType": "github",
       "computedHash": "d1fb6d34d48a645bc5715f91dd5ba176aad87355147e965ad49cfd4a8744d9a7"
+    },
+    "skill-creator": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "computedHash": "57f470f512f45bdac598e302bc72fd62bf2b649fc7fad032efe97720149cde4d"
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -11,10 +11,25 @@
       "sourceType": "github",
       "computedHash": "645b891da1edbae76ab79c7b088d4e73397464f8396edaf773c0e01971ce75d6"
     },
+    "gh-cli": {
+      "source": "github/awesome-copilot",
+      "sourceType": "github",
+      "computedHash": "cbe644b0c6760ae2a1eaafa39133920d889331327065d92a131675a665273e56"
+    },
     "modern-python": {
       "source": "trailofbits/skills",
       "sourceType": "github",
       "computedHash": "cf3f5314887a7726b3a18be574dcb4c753e74ce5105d5496d1f18c802c9e4e77"
+    },
+    "prd": {
+      "source": "github/awesome-copilot",
+      "sourceType": "github",
+      "computedHash": "1f3e1f005fc40fda85d250ae906c8ee4f7e8e833e23adfeca6542c19609fd7cd"
+    },
+    "python-typing-ops": {
+      "source": "0xdarkmatter/claude-mods",
+      "sourceType": "github",
+      "computedHash": "729f8e9a18fef21b38c525cd3cc8232091a113b5144cb51cbf58ac8b93f9f045"
     },
     "ruff-linting": {
       "source": "laurigates/claude-plugins",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "black_ruff_mypy": {
+      "source": "davidcastagnetoa/skills",
+      "sourceType": "github",
+      "computedHash": "4ce951471a8cceb098588a3263caa1ca5204684a0e7db1c96bf9ebb614e3b77b"
+    },
     "find-skills": {
       "source": "vercel-labs/skills",
       "sourceType": "github",

--- a/src/example/app/adapters/drivens/repository/sqlalchemy.py
+++ b/src/example/app/adapters/drivens/repository/sqlalchemy.py
@@ -1,38 +1,157 @@
+from dataclasses import dataclass
+from typing import Mapping
 from uuid import UUID
 
 from eventsourcing.persistence import Mapper
 
 from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.adapters.drivens.repository.sqlalchemy import (
+    SQLAlchemyContactoRepositoryAdapter,
     SQLAlchemyContactoAppInfrastructure,
+    SQLAlchemyEntidadContactoRepositoryAdapter,
+    SQLAlchemyEntidadRepositoryAdapter,
 )
 from hexagonal.adapters.drivens.repository.sqlalchemy import (
     SQLAlchemyConnectionContextManager,
+    SQLAlchemyDatastore,
+    SQLAlchemyInboxRepository,
+    SQLAlchemyOutboxRepository,
+    SQLAlchemyScopeRunner,
     SQLAlchemyUnitOfWork,
 )
-from hexagonal.application import ComposableInfrastructure, InfrastructureGroup
+from hexagonal.application import Infrastructure
+
+
+@dataclass(frozen=True)
+class ExampleSQLAlchemyWriteScope:
+    uow: SQLAlchemyUnitOfWork
+    contacto_repository: SQLAlchemyContactoRepositoryAdapter
+    entidad_repository: SQLAlchemyEntidadRepositoryAdapter
+    entidad_contacto_repository: SQLAlchemyEntidadContactoRepositoryAdapter
+    inbox_repository: SQLAlchemyInboxRepository
+    outbox_repository: SQLAlchemyOutboxRepository
 
 
 class exampleSQLAlchemyInfrastructure(
-    IexampleInfrastructure[SQLAlchemyConnectionContextManager], InfrastructureGroup
+    IexampleInfrastructure[SQLAlchemyConnectionContextManager], Infrastructure
 ):
     def __init__(
         self,
         mapper: Mapper[UUID],
-        manager: SQLAlchemyConnectionContextManager,
-        uow: SQLAlchemyUnitOfWork | None = None,
+        datastore: SQLAlchemyDatastore,
     ):
-        self._uow = uow or SQLAlchemyUnitOfWork(connection_manager=manager)
-        self._contacto = SQLAlchemyContactoAppInfrastructure(manager, mapper, self._uow)
-        infra: ComposableInfrastructure = self._contacto
-        if uow is None:
-            infra = infra & self._uow
-        super().__init__(infra)
+        super().__init__()
+        self._mapper = mapper
+        self._datastore = datastore
+        self._env: Mapping[str, str] = {}
+        self._scope_runner = SQLAlchemyScopeRunner(
+            self.create_write_scope,
+            self.create_read_scope,
+        )
+        self._uow: SQLAlchemyUnitOfWork | None = None
+        self._contacto: SQLAlchemyContactoAppInfrastructure | None = None
+
+    def initialize(self, env: Mapping[str, str]) -> None:
+        self._env = dict(env)
+        compatibility_manager = self.create_read_scope()
+        self._uow = SQLAlchemyUnitOfWork(connection_manager=compatibility_manager)
+        self._uow.initialize(self._env)
+        self._contacto = SQLAlchemyContactoAppInfrastructure(
+            compatibility_manager,
+            self._mapper,
+            self._uow,
+        )
+        self._contacto.initialize(self._env)
+        self._initialized = True
+
+    def create_read_scope(self) -> SQLAlchemyConnectionContextManager:
+        return SQLAlchemyConnectionContextManager(self._datastore)
+
+    def build_contacto_repository(
+        self, manager: SQLAlchemyConnectionContextManager
+    ) -> SQLAlchemyContactoRepositoryAdapter:
+        repository = SQLAlchemyContactoRepositoryAdapter(self._mapper, manager)
+        repository.initialize(self._env)
+        return repository
+
+    def build_entidad_repository(
+        self, manager: SQLAlchemyConnectionContextManager
+    ) -> SQLAlchemyEntidadRepositoryAdapter:
+        repository = SQLAlchemyEntidadRepositoryAdapter(self._mapper, manager)
+        repository.initialize(self._env)
+        return repository
+
+    def build_entidad_contacto_repository(
+        self, manager: SQLAlchemyConnectionContextManager
+    ) -> SQLAlchemyEntidadContactoRepositoryAdapter:
+        repository = SQLAlchemyEntidadContactoRepositoryAdapter(self._mapper, manager)
+        repository.initialize(self._env)
+        return repository
+
+    def build_inbox_repository(
+        self, manager: SQLAlchemyConnectionContextManager
+    ) -> SQLAlchemyInboxRepository:
+        repository = SQLAlchemyInboxRepository(self._mapper, manager)
+        repository.initialize(self._env)
+        return repository
+
+    def build_outbox_repository(
+        self, manager: SQLAlchemyConnectionContextManager
+    ) -> SQLAlchemyOutboxRepository:
+        repository = SQLAlchemyOutboxRepository(self._mapper, manager)
+        repository.initialize(self._env)
+        return repository
+
+    def create_write_scope(self) -> ExampleSQLAlchemyWriteScope:
+        manager = self.create_read_scope()
+        contacto_repository = self.build_contacto_repository(manager)
+        entidad_repository = self.build_entidad_repository(manager)
+        entidad_contacto_repository = self.build_entidad_contacto_repository(manager)
+        inbox_repository = self.build_inbox_repository(manager)
+        outbox_repository = self.build_outbox_repository(manager)
+        uow = SQLAlchemyUnitOfWork(
+            contacto_repository,
+            entidad_repository,
+            entidad_contacto_repository,
+            inbox_repository,
+            outbox_repository,
+            connection_manager=manager,
+        )
+        if self._env:
+            uow.initialize(self._env)
+        return ExampleSQLAlchemyWriteScope(
+            uow=uow,
+            contacto_repository=contacto_repository,
+            entidad_repository=entidad_repository,
+            entidad_contacto_repository=entidad_contacto_repository,
+            inbox_repository=inbox_repository,
+            outbox_repository=outbox_repository,
+        )
 
     @property
     def uow(self) -> SQLAlchemyUnitOfWork:
+        if self._uow is None:
+            raise RuntimeError("Example infrastructure not initialized")
         return self._uow
 
     @property
     def contacto(self) -> SQLAlchemyContactoAppInfrastructure:
+        if self._contacto is None:
+            raise RuntimeError("Example infrastructure not initialized")
         return self._contacto
+
+    @property
+    def write_scope_runner(
+        self,
+    ) -> SQLAlchemyScopeRunner[
+        ExampleSQLAlchemyWriteScope, SQLAlchemyConnectionContextManager
+    ]:
+        return self._scope_runner
+
+    @property
+    def read_scope_runner(
+        self,
+    ) -> SQLAlchemyScopeRunner[
+        ExampleSQLAlchemyWriteScope, SQLAlchemyConnectionContextManager
+    ]:
+        return self._scope_runner

--- a/src/example/app/adapters/drivens/repository/sqlalchemy.py
+++ b/src/example/app/adapters/drivens/repository/sqlalchemy.py
@@ -6,12 +6,14 @@ from eventsourcing.persistence import Mapper
 
 from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.adapters.drivens.repository.sqlalchemy import (
-    SQLAlchemyContactoRepositoryAdapter,
     SQLAlchemyContactoAppInfrastructure,
+    SQLAlchemyContactoRepositoryAdapter,
     SQLAlchemyEntidadContactoRepositoryAdapter,
     SQLAlchemyEntidadRepositoryAdapter,
 )
-from hexagonal.application import ComposableInfrastructure, InfrastructureGroup
+from hexagonal.application import (
+    Infrastructure,
+)
 from hexagonal.integrations.sqlalchemy import (
     SQLAlchemyConnectionContextManager,
     SQLAlchemyDatastore,
@@ -20,7 +22,6 @@ from hexagonal.integrations.sqlalchemy import (
     SQLAlchemyScopeRunner,
     SQLAlchemyUnitOfWork,
 )
-from hexagonal.application import Infrastructure
 
 
 @dataclass(frozen=True)

--- a/src/example/app/adapters/drivens/repository/sqlalchemy.py
+++ b/src/example/app/adapters/drivens/repository/sqlalchemy.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass
 from typing import Mapping
 from uuid import UUID
 
-from eventsourcing.persistence import Mapper
-
 from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.adapters.drivens.repository.sqlalchemy import (
     SQLAlchemyContactoAppInfrastructure,
@@ -14,6 +12,7 @@ from example.contacto.adapters.drivens.repository.sqlalchemy import (
 from hexagonal.application import (
     Infrastructure,
 )
+from hexagonal.adapters.drivens.mappers import MessageMapper
 from hexagonal.integrations.sqlalchemy import (
     SQLAlchemyConnectionContextManager,
     SQLAlchemyDatastore,
@@ -39,9 +38,9 @@ class exampleSQLAlchemyInfrastructure(
 ):
     def __init__(
         self,
-        mapper: Mapper[UUID],
+        mapper: MessageMapper,
         datastore: SQLAlchemyDatastore,
-    ):
+    ) -> None:
         super().__init__()
         self._mapper = mapper
         self._datastore = datastore

--- a/src/example/app/adapters/drivens/repository/sqlalchemy.py
+++ b/src/example/app/adapters/drivens/repository/sqlalchemy.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from typing import Mapping
-from uuid import UUID
 
 from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.adapters.drivens.repository.sqlalchemy import (
@@ -9,10 +8,8 @@ from example.contacto.adapters.drivens.repository.sqlalchemy import (
     SQLAlchemyEntidadContactoRepositoryAdapter,
     SQLAlchemyEntidadRepositoryAdapter,
 )
-from hexagonal.application import (
-    Infrastructure,
-)
 from hexagonal.adapters.drivens.mappers import MessageMapper
+from hexagonal.application import Infrastructure
 from hexagonal.integrations.sqlalchemy import (
     SQLAlchemyConnectionContextManager,
     SQLAlchemyDatastore,

--- a/src/example/app/adapters/drivers/proxy_adapters.py
+++ b/src/example/app/adapters/drivers/proxy_adapters.py
@@ -1,18 +1,33 @@
 from example.app.ports.drivers import IexampleApp
-from hexagonal.ports.drivens import TManager
+from example.app.ports.drivens import IexampleInfrastructure
+from hexagonal.ports.drivens import (
+    ICommandBus,
+    IEventBus,
+    IQueryBus,
+    IUnitOfWork,
+    TManager,
+)
 
 
 class exampleAppProxyAdapter(IexampleApp[TManager]):
-    def __init__(self, app: IexampleApp[TManager]):
+    def __init__(self, app: IexampleApp[TManager]) -> None:
         self.app = app
 
     @property
-    def uow(self):
+    def uow(self) -> IUnitOfWork[TManager]:
         return self.app.uow
 
-    def bootstrap(self, command_bus, query_bus, event_bus):  # type: ignore
-        return self.app.bootstrap(command_bus, query_bus, event_bus)
+    def bootstrap(
+        self,
+        command_bus: ICommandBus[TManager],
+        query_bus: IQueryBus[TManager],
+        event_bus: IEventBus[TManager],
+    ) -> None:
+        self.app.bootstrap(command_bus, query_bus, event_bus)
 
     @property
-    def infrastructure(self):
+    def infrastructure(self) -> IexampleInfrastructure[TManager]:
         return self.app.infrastructure
+
+
+__all__ = ["exampleAppProxyAdapter"]

--- a/src/example/app/adapters/drivers/proxy_adapters.py
+++ b/src/example/app/adapters/drivers/proxy_adapters.py
@@ -1,5 +1,5 @@
-from example.app.ports.drivers import IexampleApp
 from example.app.ports.drivens import IexampleInfrastructure
+from example.app.ports.drivers import IexampleApp
 from hexagonal.ports.drivens import (
     ICommandBus,
     IEventBus,

--- a/src/example/app/application/app.py
+++ b/src/example/app/application/app.py
@@ -17,13 +17,21 @@ class exampleBusApp(ComposableBusApp[TManager]):
         return self._infra.uow
 
     def bootstrap(self, command_bus, query_bus, event_bus) -> None:
-        pass
+        command_bus.configure_scope_runtime(
+            write_scope_runner=self._infra.write_scope_runner,
+            outbox_repository_getter=lambda scope: scope.outbox_repository,
+        )
+        event_bus.configure_scope_runtime(
+            write_scope_runner=self._infra.write_scope_runner,
+            outbox_repository_getter=lambda scope: scope.outbox_repository,
+        )
+        query_bus.configure_read_scope_runtime(self._infra.read_scope_runner)
 
 
 class exampleApp(IexampleApp[TManager], ComposableBusApp[TManager]):
     def __init__(self, infrastructure: IexampleInfrastructure[TManager]):
         self._infrastructure = infrastructure
-        contacto = ContactoApp(infrastructure.contacto)
+        contacto = ContactoApp(infrastructure.contacto, infrastructure)
         self._buses = exampleBusApp(infrastructure)
         super().__init__(contacto + self._buses)
 

--- a/src/example/app/application/app.py
+++ b/src/example/app/application/app.py
@@ -4,19 +4,30 @@ from example.app.ports.drivens import IexampleInfrastructure
 from example.app.ports.drivers import IexampleApp
 from example.contacto.application import ContactoApp
 from hexagonal.application import ComposableBusApp
-from hexagonal.ports.drivens import TManager
+from hexagonal.ports.drivens import (
+    ICommandBus,
+    IEventBus,
+    IQueryBus,
+    IUnitOfWork,
+    TManager,
+)
 
 
 class exampleBusApp(ComposableBusApp[TManager]):
-    def __init__(self, infrastructure: IexampleInfrastructure[TManager]):
+    def __init__(self, infrastructure: IexampleInfrastructure[TManager]) -> None:
         infrastructure.verify()
         self._infra = infrastructure
 
     @property
-    def uow(self):
+    def uow(self) -> IUnitOfWork[TManager]:
         return self._infra.uow
 
-    def bootstrap(self, command_bus, query_bus, event_bus) -> None:
+    def bootstrap(
+        self,
+        command_bus: ICommandBus[TManager],
+        query_bus: IQueryBus[TManager],
+        event_bus: IEventBus[TManager],
+    ) -> None:
         command_bus.configure_scope_runtime(
             write_scope_runner=self._infra.write_scope_runner,
             outbox_repository_getter=lambda scope: scope.outbox_repository,
@@ -29,7 +40,7 @@ class exampleBusApp(ComposableBusApp[TManager]):
 
 
 class exampleApp(IexampleApp[TManager], ComposableBusApp[TManager]):
-    def __init__(self, infrastructure: IexampleInfrastructure[TManager]):
+    def __init__(self, infrastructure: IexampleInfrastructure[TManager]) -> None:
         self._infrastructure = infrastructure
         contacto = ContactoApp(infrastructure.contacto, infrastructure)
         self._buses = exampleBusApp(infrastructure)
@@ -38,3 +49,6 @@ class exampleApp(IexampleApp[TManager], ComposableBusApp[TManager]):
     @property
     def infrastructure(self) -> IexampleInfrastructure[TManager]:
         return self._infrastructure
+
+
+__all__ = ["exampleApp", "exampleBusApp"]

--- a/src/example/app/entrypoints/db/sqlalchemy.py
+++ b/src/example/app/entrypoints/db/sqlalchemy.py
@@ -1,5 +1,7 @@
 # pyright: reportMissingParameterType=none, reportGeneralTypeIssues=none
 
+from typing import Mapping
+
 from example.app.adapters.drivens.repository.sqlalchemy import (
     exampleSQLAlchemyInfrastructure,
 )
@@ -22,7 +24,9 @@ class SQLAlchemyexampleEntrypoint(
     }
 
     @classmethod
-    def get(cls, env=None):
+    def get(
+        cls, env: Mapping[str, str] | None = None
+    ) -> IexampleApp[SQLAlchemyConnectionContextManager]:
         env = cls.construct_env(env)
         sqlalchemy_infra = SQLAlchemyInfrastructureEntrypoint.get(env)
         datastore: SQLAlchemyDatastore = sqlalchemy_infra.datastore
@@ -34,3 +38,10 @@ class SQLAlchemyexampleEntrypoint(
         app = exampleApp(infrastructure)
         application = exampleAppProxyAdapter(app)
         return application
+
+
+__all__ = [
+    "SQLAlchemyConnectionContextManager",
+    "SQLAlchemyDatastore",
+    "SQLAlchemyexampleEntrypoint",
+]

--- a/src/example/app/entrypoints/db/sqlalchemy.py
+++ b/src/example/app/entrypoints/db/sqlalchemy.py
@@ -8,6 +8,7 @@ from example.app.application import exampleApp
 from example.app.ports.drivers import IexampleApp
 from hexagonal.adapters.drivens.repository.sqlalchemy import (
     SQLAlchemyConnectionContextManager,
+    SQLAlchemyDatastore,
 )
 from hexagonal.entrypoints import Entrypoint
 from hexagonal.entrypoints.sqlalchemy import SQLAlchemyInfrastructureEntrypoint
@@ -24,9 +25,10 @@ class SQLAlchemyexampleEntrypoint(
     def get(cls, env=None):
         env = cls.construct_env(env)
         sqlalchemy_infra = SQLAlchemyInfrastructureEntrypoint.get(env)
+        datastore: SQLAlchemyDatastore = sqlalchemy_infra.datastore
         infrastructure = exampleSQLAlchemyInfrastructure(
             sqlalchemy_infra.mapper,
-            sqlalchemy_infra.connection_manager,
+            datastore,
         )
         infrastructure.initialize(env)
         app = exampleApp(infrastructure)

--- a/src/example/app/entrypoints/example.py
+++ b/src/example/app/entrypoints/example.py
@@ -11,7 +11,7 @@ class Sqlalchemy(Entrypoint[IexampleApp[Any]]):
     name = "sqlalchemy"
 
     @classmethod
-    def get(cls, env: Optional[Mapping[str, str]] = None):
+    def get(cls, env: Optional[Mapping[str, str]] = None) -> IexampleApp[Any]:
         from .db.sqlalchemy import SQLAlchemyexampleEntrypoint
 
         return SQLAlchemyexampleEntrypoint.get(env)
@@ -21,3 +21,6 @@ class exampleBusAppEntrypoint(EntrypointGroup[IexampleApp[Any]]):
     env_key = "ENV_REPOSITORY"
     entrypoints = [Sqlalchemy]
     env = {"ENV_REPOSITORY": "sqlalchemy"}
+
+
+__all__ = ["Sqlalchemy", "exampleBusAppEntrypoint"]

--- a/src/example/app/entrypoints/main.py
+++ b/src/example/app/entrypoints/main.py
@@ -13,7 +13,7 @@ class Sqlalchemy(Entrypoint[IBaseApplication[Any]]):
     name = "sqlalchemy"
 
     @classmethod
-    def get(cls, env: Mapping[str, str] | None = None):
+    def get(cls, env: Mapping[str, str] | None = None) -> IBaseApplication[Any]:
         from hexagonal.entrypoints.sqlalchemy import SQLAlchemyAppEntrypoint
 
         from .db.sqlalchemy import (
@@ -32,3 +32,6 @@ class exampleEntrypoint(EntrypointGroup[IBaseApplication[Any]]):
     env_key = "ENV_REPOSITORY"
     entrypoints = [Sqlalchemy]
     env = {"ENV_REPOSITORY": "sqlalchemy"}
+
+
+__all__ = ["Sqlalchemy", "exampleEntrypoint"]

--- a/src/example/app/ports/drivens.py
+++ b/src/example/app/ports/drivens.py
@@ -3,10 +3,15 @@ from typing import Generic
 
 from example.contacto.ports.drivens import (
     IAppContactoInfrastructure,
+    IContactoRepository,
     IContactoWriteScope,
+    IEntidadContactoRepository,
+    IEntidadRepository,
 )
 from hexagonal.ports.drivens import (
     IBaseInfrastructure,
+    IInboxRepository,
+    IOutboxRepository,
     IReadScopeFactory,
     IReadScopeRunner,
     IUnitOfWork,
@@ -41,16 +46,26 @@ class IexampleInfrastructure(
     def read_scope_runner(self) -> IReadScopeRunner[TManager]: ...
 
     @abstractmethod
-    def build_contacto_repository(self, manager: TManager): ...
+    def build_contacto_repository(
+        self, manager: TManager
+    ) -> IContactoRepository[TManager]: ...
 
     @abstractmethod
-    def build_entidad_repository(self, manager: TManager): ...
+    def build_entidad_repository(
+        self, manager: TManager
+    ) -> IEntidadRepository[TManager]: ...
 
     @abstractmethod
-    def build_entidad_contacto_repository(self, manager: TManager): ...
+    def build_entidad_contacto_repository(
+        self, manager: TManager
+    ) -> IEntidadContactoRepository[TManager]: ...
 
     @abstractmethod
-    def build_inbox_repository(self, manager: TManager): ...
+    def build_inbox_repository(
+        self, manager: TManager
+    ) -> IInboxRepository[TManager]: ...
 
     @abstractmethod
-    def build_outbox_repository(self, manager: TManager): ...
+    def build_outbox_repository(
+        self, manager: TManager
+    ) -> IOutboxRepository[TManager]: ...

--- a/src/example/app/ports/drivens.py
+++ b/src/example/app/ports/drivens.py
@@ -1,11 +1,27 @@
 from abc import abstractmethod
 from typing import Generic
 
-from example.contacto.ports.drivens import IAppContactoInfrastructure
-from hexagonal.ports.drivens import IBaseInfrastructure, IUnitOfWork, TManager
+from example.contacto.ports.drivens import (
+    IAppContactoInfrastructure,
+    IContactoWriteScope,
+)
+from hexagonal.ports.drivens import (
+    IBaseInfrastructure,
+    IReadScopeFactory,
+    IReadScopeRunner,
+    IUnitOfWork,
+    IWriteScopeFactory,
+    IWriteScopeRunner,
+    TManager,
+)
 
 
-class IexampleInfrastructure(IBaseInfrastructure, Generic[TManager]):
+class IexampleInfrastructure(
+    IBaseInfrastructure,
+    IWriteScopeFactory[IContactoWriteScope[TManager]],
+    IReadScopeFactory[TManager],
+    Generic[TManager],
+):
     @property
     @abstractmethod
     def uow(self) -> IUnitOfWork[TManager]: ...
@@ -13,3 +29,28 @@ class IexampleInfrastructure(IBaseInfrastructure, Generic[TManager]):
     @property
     @abstractmethod
     def contacto(self) -> IAppContactoInfrastructure[TManager]: ...
+
+    @property
+    @abstractmethod
+    def write_scope_runner(
+        self,
+    ) -> IWriteScopeRunner[IContactoWriteScope[TManager]]: ...
+
+    @property
+    @abstractmethod
+    def read_scope_runner(self) -> IReadScopeRunner[TManager]: ...
+
+    @abstractmethod
+    def build_contacto_repository(self, manager: TManager): ...
+
+    @abstractmethod
+    def build_entidad_repository(self, manager: TManager): ...
+
+    @abstractmethod
+    def build_entidad_contacto_repository(self, manager: TManager): ...
+
+    @abstractmethod
+    def build_inbox_repository(self, manager: TManager): ...
+
+    @abstractmethod
+    def build_outbox_repository(self, manager: TManager): ...

--- a/src/example/contacto/adapters/drivens/repository/sqlalchemy/contacto.py
+++ b/src/example/contacto/adapters/drivens/repository/sqlalchemy/contacto.py
@@ -41,7 +41,7 @@ class SQLAlchemyContactoRepositoryAdapter(
         self, conn: Connection, snap: AggregateSnapshot[SnapshotState[IdContacto]]
     ) -> None:
         super()._insert_snapshot(conn, snap)
-        state = cast(Exampletate, snap.state)  # type: ignore
+        state = cast(Exampletate, snap.state)
         usuario = state.usuario_validacion.value if state.usuario_validacion else None
         user_create = state.usuario_creacion.value if state.usuario_creacion else None
         stmt = insert(ContactoModel).values(
@@ -62,7 +62,7 @@ class SQLAlchemyContactoRepositoryAdapter(
         self, conn: Connection, snap: AggregateSnapshot[SnapshotState[IdContacto]]
     ) -> None:
         super()._update_snapshot(conn, snap)
-        state = cast(Exampletate, snap.state)  # type: ignore
+        state = cast(Exampletate, snap.state)
         usuario = state.usuario_validacion.value if state.usuario_validacion else None
         user_create = state.usuario_creacion.value if state.usuario_creacion else None
         stmt = (

--- a/src/example/contacto/adapters/drivens/repository/sqlalchemy/entidad.py
+++ b/src/example/contacto/adapters/drivens/repository/sqlalchemy/entidad.py
@@ -104,7 +104,7 @@ class SQLAlchemyEntidadRepositoryAdapter(
                 f"TipoEntidad {entity.value.tipo} not supported for update"
             )
 
-    def _delete(self, conn: Connection, id: IdEntidad):
+    def _delete(self, conn: Connection, id: IdEntidad) -> None:
         stmt = select(EntidadModel).where(EntidadModel.id_entidad == id.value)
         result = conn.execute(stmt).fetchone()
         if not result:
@@ -124,7 +124,7 @@ class SQLAlchemyEntidadRepositoryAdapter(
         stmt_delete = delete(EntidadModel).where(EntidadModel.id_entidad == id.value)
         conn.execute(stmt_delete)
 
-    def save(self, entity):
+    def save(self, entity: Entidad) -> None:
         """Save an entity to the repository."""
         self.verify()
         with self.connection_manager.cursor() as conn:

--- a/src/example/contacto/adapters/drivens/repository/sqlalchemy/entidad_contacto.py
+++ b/src/example/contacto/adapters/drivens/repository/sqlalchemy/entidad_contacto.py
@@ -45,7 +45,7 @@ class SQLAlchemyEntidadContactoRepositoryAdapter(
         snap: AggregateSnapshot[SnapshotState[IdEntidadContacto]],
     ) -> None:
         super()._insert_snapshot(conn, snap)
-        state = cast(EntidadExampletate, snap.state)  # type: ignore
+        state = cast(EntidadExampletate, snap.state)
         stmt = insert(EntidadContactoModel).values(
             id_entidad=state.entidad.value,
             id_contacto=state.contacto.value,
@@ -67,7 +67,7 @@ class SQLAlchemyEntidadContactoRepositoryAdapter(
         snap: AggregateSnapshot[SnapshotState[IdEntidadContacto]],
     ) -> None:
         super()._update_snapshot(conn, snap)
-        state = cast(EntidadExampletate, snap.state)  # type: ignore
+        state = cast(EntidadExampletate, snap.state)
         stmt = (
             update(EntidadContactoModel)
             .where(

--- a/src/example/contacto/adapters/drivens/repository/sqlalchemy/entidad_contacto.py
+++ b/src/example/contacto/adapters/drivens/repository/sqlalchemy/entidad_contacto.py
@@ -18,11 +18,11 @@ from example.database.entidad_contacto import (
     ValidacionContactoEntidad as ValidacionContactoEntidadModel,
 )
 from example.shared.mapper_enum_tables import MapperEnumTables
+from hexagonal.domain import AggregateSnapshot, SnapshotState
 from hexagonal.integrations.sqlalchemy import (
     SQLAlchemyConnectionContextManager,
     SQLAlchemyRepositoryAdapter,
 )
-from hexagonal.domain import AggregateSnapshot, SnapshotState
 
 
 class SQLAlchemyEntidadContactoRepositoryAdapter(

--- a/src/example/contacto/adapters/drivens/repository/sqlalchemy/infra.py
+++ b/src/example/contacto/adapters/drivens/repository/sqlalchemy/infra.py
@@ -3,11 +3,11 @@ from uuid import UUID
 from eventsourcing.persistence import Mapper
 
 from example.contacto.ports.drivens import IAppContactoInfrastructure
+from hexagonal.application import InfrastructureGroup
 from hexagonal.integrations.sqlalchemy import (
     SQLAlchemyConnectionContextManager,
     SQLAlchemyUnitOfWork,
 )
-from hexagonal.application import InfrastructureGroup
 
 from .contacto import SQLAlchemyContactoRepositoryAdapter
 from .entidad import SQLAlchemyEntidadRepositoryAdapter

--- a/src/example/contacto/adapters/drivens/repository/sqlalchemy/infra.py
+++ b/src/example/contacto/adapters/drivens/repository/sqlalchemy/infra.py
@@ -1,8 +1,5 @@
-from uuid import UUID
-
-from eventsourcing.persistence import Mapper
-
 from example.contacto.ports.drivens import IAppContactoInfrastructure
+from hexagonal.adapters.drivens.mappers import MessageMapper
 from hexagonal.application import InfrastructureGroup
 from hexagonal.integrations.sqlalchemy import (
     SQLAlchemyConnectionContextManager,
@@ -21,9 +18,9 @@ class SQLAlchemyContactoAppInfrastructure(
     def __init__(
         self,
         manager: SQLAlchemyConnectionContextManager,
-        mapper: Mapper[UUID],
+        mapper: MessageMapper,
         uow: SQLAlchemyUnitOfWork | None = None,
-    ):
+    ) -> None:
         self._contacto_repository = SQLAlchemyContactoRepositoryAdapter(
             mapper,
             manager,
@@ -46,17 +43,17 @@ class SQLAlchemyContactoAppInfrastructure(
         )
 
     @property
-    def contacto_repository(self):
+    def contacto_repository(self) -> SQLAlchemyContactoRepositoryAdapter:
         return self._contacto_repository
 
     @property
-    def entidad_contacto_repository(self):
+    def entidad_contacto_repository(self) -> SQLAlchemyEntidadContactoRepositoryAdapter:
         return self._entidad_contacto_repository
 
     @property
-    def uow(self):
+    def uow(self) -> SQLAlchemyUnitOfWork:
         return self._uow
 
     @property
-    def entidad_repository(self):
+    def entidad_repository(self) -> SQLAlchemyEntidadRepositoryAdapter:
         return self._entidad_repository

--- a/src/example/contacto/adapters/drivers/app.py
+++ b/src/example/contacto/adapters/drivers/app.py
@@ -1,18 +1,33 @@
 from example.contacto.ports.drivers import IContactoApp
-from hexagonal.ports.drivens import TManager
+from example.contacto.ports.drivens import IAppContactoInfrastructure
+from hexagonal.ports.drivens import (
+    ICommandBus,
+    IEventBus,
+    IQueryBus,
+    IUnitOfWork,
+    TManager,
+)
 
 
 class ContactoAppProxyAdapter(IContactoApp[TManager]):
-    def __init__(self, app: IContactoApp[TManager]):
+    def __init__(self, app: IContactoApp[TManager]) -> None:
         self.app = app
 
     @property
-    def uow(self):
+    def uow(self) -> IUnitOfWork[TManager]:
         return self.app.uow
 
-    def bootstrap(self, command_bus, query_bus, event_bus):  # type: ignore
-        return self.app.bootstrap(command_bus, query_bus, event_bus)
+    def bootstrap(
+        self,
+        command_bus: ICommandBus[TManager],
+        query_bus: IQueryBus[TManager],
+        event_bus: IEventBus[TManager],
+    ) -> None:
+        self.app.bootstrap(command_bus, query_bus, event_bus)
 
     @property
-    def infrastructure(self):
+    def infrastructure(self) -> IAppContactoInfrastructure[TManager]:
         return self.app.infrastructure
+
+
+__all__ = ["ContactoAppProxyAdapter"]

--- a/src/example/contacto/adapters/drivers/app.py
+++ b/src/example/contacto/adapters/drivers/app.py
@@ -1,5 +1,5 @@
-from example.contacto.ports.drivers import IContactoApp
 from example.contacto.ports.drivens import IAppContactoInfrastructure
+from example.contacto.ports.drivers import IContactoApp
 from hexagonal.ports.drivens import (
     ICommandBus,
     IEventBus,

--- a/src/example/contacto/application/app.py
+++ b/src/example/contacto/application/app.py
@@ -1,3 +1,4 @@
+from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.ports.drivens import IAppContactoInfrastructure
 from example.contacto.ports.drivers import IContactoApp
 from hexagonal.application import BusAppGroup
@@ -10,25 +11,17 @@ from .integration_handlers import IntegrationContactoBusApp
 
 
 class ContactoApp(IContactoApp[TManager], BusAppGroup[TManager]):
-    def __init__(self, infrastructure: IAppContactoInfrastructure[TManager]):
+    def __init__(
+        self,
+        infrastructure: IAppContactoInfrastructure[TManager],
+        scope_provider: IexampleInfrastructure[TManager],
+    ):
         infrastructure.verify()
         self._infra = infrastructure
-        contacto = ContactoBusApp(
-            infrastructure.uow,
-            infrastructure.contacto_repository,
-        )
-        entidad = EntidadBusApp(
-            infrastructure.uow,
-            infrastructure.entidad_repository,
-        )
-        entidad_contacto = EntidadContactoBusApp(
-            infrastructure.uow,
-            infrastructure.entidad_contacto_repository,
-        )
-        integrations = IntegrationContactoBusApp(
-            infrastructure.uow,
-            infrastructure.contacto_repository,
-        )
+        contacto = ContactoBusApp(infrastructure.uow, scope_provider)
+        entidad = EntidadBusApp(infrastructure.uow, scope_provider)
+        entidad_contacto = EntidadContactoBusApp(infrastructure.uow, scope_provider)
+        integrations = IntegrationContactoBusApp(infrastructure.uow, scope_provider)
         super().__init__(
             infrastructure.uow,
             contacto,

--- a/src/example/contacto/application/contacto/api.py
+++ b/src/example/contacto/application/contacto/api.py
@@ -2,12 +2,14 @@ from typing import Any, List, Optional, Type
 from uuid import UUID
 
 from example.contacto.domain.contacto import (
+    Contacto,
     EstadoContacto,
     Exampletate,
     GetContactoById,
 )
 from example.contacto.domain.shared import TipoContacto
 from hexagonal.application import BaseAPI, TBaseApp
+from hexagonal.application.api import ApiCommandResponse
 from hexagonal.domain import AggregateSnapshot, TEvento
 
 from .use_cases import (
@@ -46,7 +48,7 @@ class ContactoAPI(BaseAPI[TBaseApp]):
         events: Optional[List[Type[TEvento]]] = None,
         async_dispatch: bool = False,
         **kwargs: Any,
-    ):
+    ) -> ApiCommandResponse[CrearContacto]:
         command = CrearContacto.new(tipo_contacto, contacto, usuario)
         return self._dispatch_command(
             command,
@@ -56,7 +58,7 @@ class ContactoAPI(BaseAPI[TBaseApp]):
             **kwargs,
         )
 
-    def get(self, id_contacto: UUID):
+    def get(self, id_contacto: UUID) -> Contacto:
         return self._get_aggregate(id_contacto, GetContactoById)
 
     def validar(
@@ -68,7 +70,7 @@ class ContactoAPI(BaseAPI[TBaseApp]):
         events: Optional[List[Type[TEvento]]] = None,
         async_dispatch: bool = False,
         **kwargs: Any,
-    ):
+    ) -> ApiCommandResponse[ValidarContacto]:
         command = ValidarContacto.new(id_contacto, validacion, usuario)
         return self._dispatch_command(
             command,

--- a/src/example/contacto/application/contacto/api.py
+++ b/src/example/contacto/application/contacto/api.py
@@ -8,8 +8,7 @@ from example.contacto.domain.contacto import (
     GetContactoById,
 )
 from example.contacto.domain.shared import TipoContacto
-from hexagonal.application import BaseAPI, TBaseApp
-from hexagonal.application.api import ApiCommandResponse
+from hexagonal.application import ApiCommandResponse, BaseAPI, TBaseApp
 from hexagonal.domain import AggregateSnapshot, TEvento
 
 from .use_cases import (

--- a/src/example/contacto/application/contacto/bus_app.py
+++ b/src/example/contacto/application/contacto/bus_app.py
@@ -1,6 +1,11 @@
+from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.domain.contacto import GetContactoById
-from example.contacto.ports.drivens import IContactoRepository
-from hexagonal.application import ComposableBusApp, GetAggregateByIdHandler
+from hexagonal.application import (
+    ComposableBusApp,
+    GetAggregateByIdHandler,
+    ScopedMessageHandlerProvider,
+    ScopedQueryHandlerProvider,
+)
 from hexagonal.ports.drivens import (
     ICommandBus,
     IEventBus,
@@ -21,10 +26,10 @@ class ContactoBusApp(ComposableBusApp[TManager]):
     def __init__(
         self,
         uow: IUnitOfWork[TManager],
-        repository: IContactoRepository[TManager],
+        scope_provider: IexampleInfrastructure[TManager],
     ):
         self._uow = uow
-        self.repository = repository
+        self.scope_provider = scope_provider
 
     @property
     def uow(self) -> IUnitOfWork[TManager]:
@@ -38,12 +43,32 @@ class ContactoBusApp(ComposableBusApp[TManager]):
     ) -> None:
         command_bus.register_handler(
             CrearContacto,
-            CrearContactoHandler(event_bus, self.uow, self.repository),
+            ScopedMessageHandlerProvider(
+                self.scope_provider.write_scope_runner,
+                lambda scope: CrearContactoHandler(
+                    event_bus,
+                    scope.uow,
+                    scope.contacto_repository,
+                ),
+            ),
         )
         command_bus.register_handler(
             ValidarContacto,
-            ValidarContactoHandler(event_bus, self.uow, self.repository),
+            ScopedMessageHandlerProvider(
+                self.scope_provider.write_scope_runner,
+                lambda scope: ValidarContactoHandler(
+                    event_bus,
+                    scope.uow,
+                    scope.contacto_repository,
+                ),
+            ),
         )
         query_bus.register_handler(
-            GetContactoById, GetAggregateByIdHandler(self.repository)
+            GetContactoById,
+            ScopedQueryHandlerProvider(
+                self.scope_provider.read_scope_runner,
+                lambda manager: GetAggregateByIdHandler(
+                    self.scope_provider.build_contacto_repository(manager)
+                ),
+            ),
         )

--- a/src/example/contacto/application/contacto/use_cases/crear_contacto.py
+++ b/src/example/contacto/application/contacto/use_cases/crear_contacto.py
@@ -29,7 +29,7 @@ class CrearContacto(ContactoCommand):
         usuario: IdUsuario | UUID | None = None,
         *_: Any,
         **__: Any,
-    ):
+    ) -> "CrearContacto":
         if isinstance(tipo_contacto, str):
             tipo_contacto = TipoContacto(tipo_contacto)
         contacto_value = ContactoValueStrategy[tipo_contacto].new(contacto)

--- a/src/example/contacto/application/contacto/use_cases/validar_contacto.py
+++ b/src/example/contacto/application/contacto/use_cases/validar_contacto.py
@@ -30,7 +30,7 @@ class ValidarContacto(ContactoCommand, topic_suffix="Validar"):
         usuario: IdUsuario | UUID,
         *_: Any,
         **__: Any,
-    ):
+    ) -> "ValidarContacto":
         if isinstance(estado, str):
             estado = EstadoContacto[estado]
         id_contacto = IdContacto.from_value(id_contacto)
@@ -44,9 +44,9 @@ class ContactoContactado(ContactoDomainEvent, topic_suffix="Contactado"):
 
     @classmethod
     def new(cls, state: Exampletate) -> "ContactoContactado":
-        assert state.usuario_validacion is not None, (
-            "El usuario de validación no puede ser None"
-        )
+        assert (
+            state.usuario_validacion is not None
+        ), "El usuario de validación no puede ser None"
         return cls(
             id_contacto=state.id,
             estado=state.estado,
@@ -60,9 +60,9 @@ class ContactoNoContactado(ContactoDomainEvent, topic_suffix="NoContactado"):
 
     @classmethod
     def new(cls, state: Exampletate) -> "ContactoNoContactado":
-        assert state.usuario_validacion is not None, (
-            "El usuario de validación no puede ser None"
-        )
+        assert (
+            state.usuario_validacion is not None
+        ), "El usuario de validación no puede ser None"
         return cls(
             id_contacto=state.id,
             estado=state.estado,
@@ -76,9 +76,9 @@ class ContactoNoContactable(ContactoDomainEvent, topic_suffix="NoContactable"):
 
     @classmethod
     def new(cls, state: Exampletate) -> "ContactoNoContactable":
-        assert state.usuario_validacion is not None, (
-            "El usuario de validación no puede ser None"
-        )
+        assert (
+            state.usuario_validacion is not None
+        ), "El usuario de validación no puede ser None"
         return cls(
             id_contacto=state.id,
             estado=state.estado,

--- a/src/example/contacto/application/entidad/api.py
+++ b/src/example/contacto/application/entidad/api.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from example.contacto.domain.entidad import Entidad, GetEntidadById
 from example.contacto.domain.shared import IdEntidad, TipoEntidad
-from hexagonal.application.api import ApiCommandResponse, BaseAPI, TBaseApp
+from hexagonal.application import ApiCommandResponse, BaseAPI, TBaseApp
 from hexagonal.domain import TEvento
 
 from .use_cases import (

--- a/src/example/contacto/application/entidad/api.py
+++ b/src/example/contacto/application/entidad/api.py
@@ -3,8 +3,7 @@ from uuid import UUID
 
 from example.contacto.domain.entidad import Entidad, GetEntidadById
 from example.contacto.domain.shared import IdEntidad, TipoEntidad
-from hexagonal.application.api import BaseAPI, TBaseApp
-from hexagonal.application.api import ApiCommandResponse
+from hexagonal.application.api import ApiCommandResponse, BaseAPI, TBaseApp
 from hexagonal.domain import TEvento
 
 from .use_cases import (

--- a/src/example/contacto/application/entidad/api.py
+++ b/src/example/contacto/application/entidad/api.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from example.contacto.domain.entidad import Entidad, GetEntidadById
 from example.contacto.domain.shared import IdEntidad, TipoEntidad
 from hexagonal.application.api import BaseAPI, TBaseApp
+from hexagonal.application.api import ApiCommandResponse
 from hexagonal.domain import TEvento
 
 from .use_cases import (
@@ -34,7 +35,7 @@ class EntidadAPI(BaseAPI[TBaseApp]):
         events: Optional[List[Type[TEvento]]] = None,
         async_dispatch: bool = False,
         **kwargs: Any,
-    ):
+    ) -> ApiCommandResponse[CrearEntidad]:
         command = CrearEntidad.new(tipo_entidad, **datos_entidad)
         return self._dispatch_command(
             command,
@@ -61,7 +62,7 @@ class EntidadAPI(BaseAPI[TBaseApp]):
         events: Optional[List[Type[TEvento]]] = None,
         async_dispatch: bool = False,
         **kwargs: Any,
-    ):
+    ) -> ApiCommandResponse[BorrarEntidad]:
         command = BorrarEntidad.new(id_entidad)
         return self._dispatch_command(
             command,

--- a/src/example/contacto/application/entidad/bus_app.py
+++ b/src/example/contacto/application/entidad/bus_app.py
@@ -1,6 +1,11 @@
+from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.domain.entidad import GetEntidadById
-from example.contacto.ports.drivens import IEntidadRepository
-from hexagonal.application import ComposableBusApp, GetEntityByIdHandler
+from hexagonal.application import (
+    ComposableBusApp,
+    GetEntityByIdHandler,
+    ScopedMessageHandlerProvider,
+    ScopedQueryHandlerProvider,
+)
 from hexagonal.ports.drivens import (
     ICommandBus,
     IEventBus,
@@ -21,10 +26,10 @@ class EntidadBusApp(ComposableBusApp[TManager]):
     def __init__(
         self,
         uow: IUnitOfWork[TManager],
-        repository: IEntidadRepository[TManager],
+        scope_provider: IexampleInfrastructure[TManager],
     ):
         self._uow = uow
-        self.repository = repository
+        self.scope_provider = scope_provider
 
     @property
     def uow(self) -> IUnitOfWork[TManager]:
@@ -38,14 +43,33 @@ class EntidadBusApp(ComposableBusApp[TManager]):
     ) -> None:
         command_bus.register_handler(
             CrearEntidad,
-            CrearEntidadHandler(event_bus, self.uow, self.repository),
+            ScopedMessageHandlerProvider(
+                self.scope_provider.write_scope_runner,
+                lambda scope: CrearEntidadHandler(
+                    event_bus,
+                    scope.uow,
+                    scope.entidad_repository,
+                ),
+            ),
         )
         command_bus.register_handler(
             BorrarEntidad,
-            BorrarEntidadHandler(event_bus, self.uow, self.repository),
+            ScopedMessageHandlerProvider(
+                self.scope_provider.write_scope_runner,
+                lambda scope: BorrarEntidadHandler(
+                    event_bus,
+                    scope.uow,
+                    scope.entidad_repository,
+                ),
+            ),
         )
 
         query_bus.register_handler(
             GetEntidadById,
-            GetEntityByIdHandler(self.repository),
+            ScopedQueryHandlerProvider(
+                self.scope_provider.read_scope_runner,
+                lambda manager: GetEntityByIdHandler(
+                    self.scope_provider.build_entidad_repository(manager)
+                ),
+            ),
         )

--- a/src/example/contacto/application/entidad/use_cases/borrar_entidad.py
+++ b/src/example/contacto/application/entidad/use_cases/borrar_entidad.py
@@ -20,7 +20,7 @@ class BorrarEntidad(EntidadCommand):
         id_entidad: IdEntidad | EntidadValue | UUID,
         *_: Any,
         **__: Any,
-    ):
+    ) -> "BorrarEntidad":
         _id = id_entidad.to_id() if isinstance(id_entidad, EntidadValue) else id_entidad
         id_entidad = IdEntidad.from_value(_id)
         return cls(id_entidad=id_entidad)

--- a/src/example/contacto/application/entidad/use_cases/crear_entidad.py
+++ b/src/example/contacto/application/entidad/use_cases/crear_entidad.py
@@ -19,7 +19,7 @@ class CrearEntidad(EntidadCommand):
         tipo_entidad: TipoEntidad | str,
         *_: Any,
         **kwargs: Any,
-    ):
+    ) -> "CrearEntidad":
         if isinstance(tipo_entidad, str):
             tipo_entidad = TipoEntidad[tipo_entidad]
         entidad_value = EntidadValueStrategy[tipo_entidad].new(**kwargs)
@@ -40,7 +40,7 @@ class EntidadCreada(EntidadDomainEvent, topic_suffix="Creada"):
 
 
 class CrearEntidadHandler(EntidadCommandHandler[CrearEntidad]):
-    def execute(self, command: CrearEntidad):
+    def execute(self, command: CrearEntidad) -> list[EntidadCreada]:
         id_entidad = command.entidad.to_id()
         entidad = Entidad(id=id_entidad, value=command.entidad)
         self.repository.save(entidad)

--- a/src/example/contacto/application/entidad_contacto/api.py
+++ b/src/example/contacto/application/entidad_contacto/api.py
@@ -1,9 +1,12 @@
 from typing import Any, List, Optional, Type
 from uuid import UUID
 
-from example.contacto.domain.entidad_contacto import ValidacionEntidadContacto
+from example.contacto.domain.entidad_contacto import (
+    EntidadExampletate,
+    ValidacionEntidadContacto,
+)
 from hexagonal.application.api import BaseAPI, TBaseApp
-from hexagonal.domain import TEvento
+from hexagonal.domain import AggregateSnapshot, TEvento
 
 from .use_cases import (
     CrearEntidadContacto,
@@ -22,6 +25,7 @@ class EntidadContactoAPI(BaseAPI[TBaseApp]):
         CREADO = EntidadContactoCreado
         CORRESPONDE = EntidadContactoCorresponde
         NO_CORRESPONDE = EntidadContactoNoCorresponde
+        AGGREGATE = AggregateSnapshot[EntidadExampletate]
 
     class Commands(BaseAPI.Commands):
         CREAR = CrearEntidadContacto

--- a/src/example/contacto/application/entidad_contacto/api.py
+++ b/src/example/contacto/application/entidad_contacto/api.py
@@ -2,10 +2,12 @@ from typing import Any, List, Optional, Type
 from uuid import UUID
 
 from example.contacto.domain.entidad_contacto import (
+    EntidadContacto,
     EntidadExampletate,
     ValidacionEntidadContacto,
 )
 from hexagonal.application.api import BaseAPI, TBaseApp
+from hexagonal.application.api import ApiCommandResponse
 from hexagonal.domain import AggregateSnapshot, TEvento
 
 from .use_cases import (
@@ -43,7 +45,7 @@ class EntidadContactoAPI(BaseAPI[TBaseApp]):
         events: Optional[List[Type[TEvento]]] = None,
         async_dispatch: bool = False,
         **kwargs: Any,
-    ):
+    ) -> ApiCommandResponse[CrearEntidadContacto]:
         command = CrearEntidadContacto.new(entidad, contacto, usuario)
         return self._dispatch_command(
             command,
@@ -53,7 +55,7 @@ class EntidadContactoAPI(BaseAPI[TBaseApp]):
             **kwargs,
         )
 
-    def get(self, id_entidad_contacto: UUID):
+    def get(self, id_entidad_contacto: UUID) -> EntidadContacto:
         return self._get_aggregate(id_entidad_contacto, GetEntidadContactoById)
 
     def validar(
@@ -66,7 +68,7 @@ class EntidadContactoAPI(BaseAPI[TBaseApp]):
         events: Optional[List[Type[TEvento]]] = None,
         async_dispatch: bool = False,
         **kwargs: Any,
-    ):
+    ) -> ApiCommandResponse[ValidarEntidadContacto]:
         command = ValidarEntidadContacto.new(
             id_entidad,
             id_contacto,

--- a/src/example/contacto/application/entidad_contacto/api.py
+++ b/src/example/contacto/application/entidad_contacto/api.py
@@ -6,8 +6,7 @@ from example.contacto.domain.entidad_contacto import (
     EntidadExampletate,
     ValidacionEntidadContacto,
 )
-from hexagonal.application.api import BaseAPI, TBaseApp
-from hexagonal.application.api import ApiCommandResponse
+from hexagonal.application.api import ApiCommandResponse, BaseAPI, TBaseApp
 from hexagonal.domain import AggregateSnapshot, TEvento
 
 from .use_cases import (

--- a/src/example/contacto/application/entidad_contacto/api.py
+++ b/src/example/contacto/application/entidad_contacto/api.py
@@ -6,7 +6,7 @@ from example.contacto.domain.entidad_contacto import (
     EntidadExampletate,
     ValidacionEntidadContacto,
 )
-from hexagonal.application.api import ApiCommandResponse, BaseAPI, TBaseApp
+from hexagonal.application import ApiCommandResponse, BaseAPI, TBaseApp
 from hexagonal.domain import AggregateSnapshot, TEvento
 
 from .use_cases import (

--- a/src/example/contacto/application/entidad_contacto/bus_app.py
+++ b/src/example/contacto/application/entidad_contacto/bus_app.py
@@ -1,5 +1,4 @@
 from example.app.ports.drivens import IexampleInfrastructure
-from example.contacto.ports.drivens import IEntidadContactoRepository
 from hexagonal.application import (
     ComposableBusApp,
     GetAggregateByIdHandler,

--- a/src/example/contacto/application/entidad_contacto/bus_app.py
+++ b/src/example/contacto/application/entidad_contacto/bus_app.py
@@ -1,5 +1,11 @@
+from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.ports.drivens import IEntidadContactoRepository
-from hexagonal.application import ComposableBusApp, GetAggregateByIdHandler
+from hexagonal.application import (
+    ComposableBusApp,
+    GetAggregateByIdHandler,
+    ScopedMessageHandlerProvider,
+    ScopedQueryHandlerProvider,
+)
 from hexagonal.ports.drivens import (
     ICommandBus,
     IEventBus,
@@ -21,10 +27,10 @@ class EntidadContactoBusApp(ComposableBusApp[TManager]):
     def __init__(
         self,
         uow: IUnitOfWork[TManager],
-        repository: IEntidadContactoRepository[TManager],
+        scope_provider: IexampleInfrastructure[TManager],
     ):
         self._uow = uow
-        self.repository: IEntidadContactoRepository[TManager] = repository
+        self.scope_provider = scope_provider
 
     @property
     def uow(self) -> IUnitOfWork[TManager]:
@@ -38,13 +44,32 @@ class EntidadContactoBusApp(ComposableBusApp[TManager]):
     ) -> None:
         command_bus.register_handler(
             CrearEntidadContacto,
-            CrearEntidadContactoHandler(event_bus, self.uow, self.repository),
+            ScopedMessageHandlerProvider(
+                self.scope_provider.write_scope_runner,
+                lambda scope: CrearEntidadContactoHandler(
+                    event_bus,
+                    scope.uow,
+                    scope.entidad_contacto_repository,
+                ),
+            ),
         )
         command_bus.register_handler(
             ValidarEntidadContacto,
-            ValidarEntidadContactoHandler(event_bus, self.uow, self.repository),
+            ScopedMessageHandlerProvider(
+                self.scope_provider.write_scope_runner,
+                lambda scope: ValidarEntidadContactoHandler(
+                    event_bus,
+                    scope.uow,
+                    scope.entidad_contacto_repository,
+                ),
+            ),
         )
         query_bus.register_handler(
             GetEntidadContactoById,
-            GetAggregateByIdHandler(self.repository),
+            ScopedQueryHandlerProvider(
+                self.scope_provider.read_scope_runner,
+                lambda manager: GetAggregateByIdHandler(
+                    self.scope_provider.build_entidad_contacto_repository(manager)
+                ),
+            ),
         )

--- a/src/example/contacto/application/entidad_contacto/use_cases/crear_entidad_contacto.py
+++ b/src/example/contacto/application/entidad_contacto/use_cases/crear_entidad_contacto.py
@@ -30,7 +30,7 @@ class CrearEntidadContacto(EntidadContactoCommand):
         usuario: IdUsuario | UUID | None = None,
         *_: Any,
         **__: Any,
-    ):
+    ) -> "CrearEntidadContacto":
         entidad_id = IdEntidad.from_value(entidad)
         contacto_id = IdContacto.from_value(contacto)
         usuario_id = IdUsuario.from_value(usuario) if usuario else None

--- a/src/example/contacto/application/entidad_contacto/use_cases/shared.py
+++ b/src/example/contacto/application/entidad_contacto/use_cases/shared.py
@@ -60,3 +60,13 @@ EntidadContactoCommandHandler = CommandHandlerBase[
 
 
 TOPICS = RegisterTopics(EntidadExamplenapshot, GetEntidadContactoById)
+
+__all__ = [
+    "EntidadContactoCommand",
+    "EntidadContactoDomainEvent",
+    "EntidadContactoIntegrationEvent",
+    "EntidadExamplenapshot",
+    "GetEntidadContactoById",
+    "TEntidadContactoEvent",
+    "TOPICS",
+]

--- a/src/example/contacto/application/entidad_contacto/use_cases/validar_entidad_contacto.py
+++ b/src/example/contacto/application/entidad_contacto/use_cases/validar_entidad_contacto.py
@@ -45,7 +45,7 @@ class ValidarEntidadContacto(EntidadContactoCommand, topic_suffix="Validar"):
         usuario: IdUsuario | UUID,
         *_: Any,
         **__: Any,
-    ):
+    ) -> "ValidarEntidadContacto":
         if isinstance(validacion, str):
             validacion = ValidacionEntidadContacto[validacion]
         if isinstance(entidad, EntidadValue):
@@ -79,12 +79,12 @@ class EntidadContactoCorresponde(
 
     @classmethod
     def new(cls, state: EntidadExampletate) -> "EntidadContactoCorresponde":
-        assert state.usuario_validacion is not None, (
-            "El usuario de validación no puede ser None"
-        )
-        assert state.validacion == ValidacionEntidadContacto.CORRESPONDE, (
-            "El estado de validación debe ser CORRESPONDE para crear este evento"
-        )
+        assert (
+            state.usuario_validacion is not None
+        ), "El usuario de validación no puede ser None"
+        assert (
+            state.validacion == ValidacionEntidadContacto.CORRESPONDE
+        ), "El estado de validación debe ser CORRESPONDE para crear este evento"
         return cls(
             id_entidad_contacto=state.id,
             entidad=state.entidad,
@@ -102,12 +102,12 @@ class EntidadContactoNoCorresponde(
 
     @classmethod
     def new(cls, state: EntidadExampletate) -> "EntidadContactoNoCorresponde":
-        assert state.usuario_validacion is not None, (
-            "El usuario de validación no puede ser None"
-        )
-        assert state.validacion == ValidacionEntidadContacto.NO_CORRESPONDE, (
-            "El estado de validación debe ser NO_CORRESPONDE para crear este evento"
-        )
+        assert (
+            state.usuario_validacion is not None
+        ), "El usuario de validación no puede ser None"
+        assert (
+            state.validacion == ValidacionEntidadContacto.NO_CORRESPONDE
+        ), "El estado de validación debe ser NO_CORRESPONDE para crear este evento"
         return cls(
             id_entidad_contacto=state.id,
             entidad=state.entidad,

--- a/src/example/contacto/application/integration_handlers.py
+++ b/src/example/contacto/application/integration_handlers.py
@@ -1,5 +1,6 @@
+from example.app.ports.drivens import IexampleInfrastructure
 from example.contacto.ports.drivens import IContactoRepository
-from hexagonal.application import ComposableBusApp
+from hexagonal.application import ComposableBusApp, ScopedMessageHandlerProvider
 from hexagonal.ports.drivens import (
     ICommandBus,
     IEventBus,
@@ -28,10 +29,10 @@ class IntegrationContactoBusApp(ComposableBusApp[TManager]):
     def __init__(
         self,
         uow: IUnitOfWork[TManager],
-        repository: IContactoRepository[TManager],
+        scope_provider: IexampleInfrastructure[TManager],
     ):
         self._uow = uow
-        self.repository: IContactoRepository[TManager] = repository
+        self.scope_provider = scope_provider
 
     @property
     def uow(self) -> IUnitOfWork[TManager]:
@@ -45,9 +46,12 @@ class IntegrationContactoBusApp(ComposableBusApp[TManager]):
     ) -> None:
         event_bus.subscribe(
             EntidadContactoCorresponde,
-            EntidadContactoCorrespondeHandler(
-                event_bus,
-                self.uow,
-                self.repository,
+            ScopedMessageHandlerProvider(
+                self.scope_provider.write_scope_runner,
+                lambda scope: EntidadContactoCorrespondeHandler(
+                    event_bus,
+                    scope.uow,
+                    scope.contacto_repository,
+                ),
             ),
         )

--- a/src/example/contacto/application/integration_handlers.py
+++ b/src/example/contacto/application/integration_handlers.py
@@ -1,5 +1,4 @@
 from example.app.ports.drivens import IexampleInfrastructure
-from example.contacto.ports.drivens import IContactoRepository
 from hexagonal.application import ComposableBusApp, ScopedMessageHandlerProvider
 from hexagonal.ports.drivens import (
     ICommandBus,

--- a/src/example/contacto/domain/contacto.py
+++ b/src/example/contacto/domain/contacto.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Self, Type
+from typing import Any, Dict, Type
 from uuid import UUID
 
 from example.contacto.domain.shared import (

--- a/src/example/contacto/domain/contacto.py
+++ b/src/example/contacto/domain/contacto.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Type
+from typing import Any, Dict, Self, Type
 from uuid import UUID
 
 from example.contacto.domain.shared import (
@@ -53,24 +53,24 @@ class Contacto(AggregateRoot[IdContacto, Exampletate]):
         self.fecha_validacion: datetime | None = None
 
     @classmethod
-    def create_id(cls, contacto: ContactoValue, *_, **__: Any):
-        return super().create_id(contacto=contacto)
+    def create_id(cls, contacto: ContactoValue, *_: Any, **__: Any) -> UUID:
+        return contacto.to_id().value
 
-    def _marcar_validacion(self, estado: EstadoContacto, usuario: IdUsuario):
+    def _marcar_validacion(self, estado: EstadoContacto, usuario: IdUsuario) -> None:
         self.estado = estado
         self.usuario_validacion = usuario
         self.fecha_validacion = self.Event.create_timestamp()
 
     @command("marcarContactado")
-    def marcar_contactado(self, usuario: IdUsuario):
+    def marcar_contactado(self, usuario: IdUsuario) -> None:
         self._marcar_validacion(EstadoContacto.CONTACTADO, usuario)
 
     @command("marcarNoContactado")
-    def marcar_no_contactado(self, usuario: IdUsuario):
+    def marcar_no_contactado(self, usuario: IdUsuario) -> None:
         self._marcar_validacion(EstadoContacto.NO_CONTACTADO, usuario)
 
     @command("marcarNoContactable")
-    def marcar_no_contactable(self, usuario: IdUsuario):
+    def marcar_no_contactable(self, usuario: IdUsuario) -> None:
         self._marcar_validacion(EstadoContacto.NO_CONTACTABLE, usuario)
 
 
@@ -80,11 +80,21 @@ class ContactoView(AggregateView[Contacto]):
 
 class GetContactoById(GetById[Contacto, IdContacto]):
     @classmethod
-    def new(cls, id: IdContacto | UUID, *_: Any, **__: Any):
+    def new(cls, id: IdContacto | UUID, *_: Any, **__: Any) -> "GetContactoById":
         id = IdContacto.from_value(id)
-        return cls(
-            id=id, view=ContactoView
-        )  # <-- Instancias directamente sin pasar por super().new()
+        return cls(id=id, view=ContactoView)
+
+
+__all__ = [
+    "Contacto",
+    "ContactoValueStrategy",
+    "ContactoView",
+    "Email",
+    "EstadoContacto",
+    "Exampletate",
+    "GetContactoById",
+    "Telefono",
+]
 
 
 # class GetContactoById(GetById[Contacto, IdContacto]):

--- a/src/example/contacto/domain/entidad.py
+++ b/src/example/contacto/domain/entidad.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, Type
+from typing import Any, Dict, Self, Type
 from uuid import UUID
 
 from example.contacto.domain.shared import EntidadValue, IdEntidad, TipoEntidad
+from hexagonal.application import AggregateView
 from hexagonal.domain import Entity, GetById
 
 
@@ -10,7 +11,7 @@ class NucleoAfiliado(EntidadValue):
     tipo: TipoEntidad = TipoEntidad.NUCLEO
 
     @classmethod
-    def new(cls, *_: Any, cd_asegurado: str, **__: Any):
+    def new(cls, *_: Any, cd_asegurado: str, **__: Any) -> Self:
         return cls(value=cd_asegurado, cd_asegurado=cd_asegurado)
 
 
@@ -24,7 +25,7 @@ class Afiliado(EntidadValue):
         return self.value
 
     @classmethod
-    def new(cls, *_: Any, cd_asegurado: str, cd_dependiente: str, **__: Any):
+    def new(cls, *_: Any, cd_asegurado: str, cd_dependiente: str, **__: Any) -> Self:
         return cls(
             value=f"{cd_asegurado}-{cd_dependiente}",
             cd_asegurado=cd_asegurado,
@@ -42,8 +43,22 @@ class Entidad(Entity[IdEntidad]):
     value: EntidadValue
 
 
+class EntidadView(AggregateView[Entidad]):
+    pass
+
+
 class GetEntidadById(GetById[Entidad, IdEntidad]):
     @classmethod
-    def new(cls, id: IdEntidad | UUID, *_: Any, **__: Any):
+    def new(cls, id: IdEntidad | UUID, *_: Any, **__: Any) -> "GetEntidadById":
         id = IdEntidad.from_value(id)
-        return super().new(id=id, agg_type=Entidad)
+        return cls(id=id, view=EntidadView)
+
+
+__all__ = [
+    "Afiliado",
+    "Entidad",
+    "EntidadValueStrategy",
+    "EntidadView",
+    "GetEntidadById",
+    "NucleoAfiliado",
+]

--- a/src/example/contacto/domain/entidad_contacto.py
+++ b/src/example/contacto/domain/entidad_contacto.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Self
 from uuid import NAMESPACE_URL, UUID, uuid5
 
 from example.contacto.domain.shared import IdContacto, IdEntidad, IdUsuario
+from hexagonal.application import AggregateView
 from hexagonal.domain import (
     AggregateRoot,
     GetById,
@@ -21,7 +22,7 @@ class IdEntidadContacto(IdValueObject):
         entidad: IdEntidad | UUID,
         contacto: IdContacto | UUID,
         **__: Any,
-    ):
+    ) -> Self:
         entidad = IdEntidad.from_value(entidad)
         contacto = IdContacto.from_value(contacto)
         return cls(
@@ -66,8 +67,14 @@ class EntidadContacto(AggregateRoot[IdEntidadContacto, EntidadExampletate]):
         self.usuario_validacion: IdUsuario | None = None
 
     @classmethod
-    def create_id(cls, entidad: IdEntidad, contacto: IdContacto, *_, **__: Any):
-        return super().create_id(entidad=entidad, contacto=contacto)
+    def create_id(
+        cls,
+        entidad: IdEntidad,
+        contacto: IdContacto,
+        *_: Any,
+        **__: Any,
+    ) -> UUID:
+        return IdEntidadContacto.new(entidad=entidad, contacto=contacto).value
 
     def complete_snapshot_state(self, state: dict[str, Any]) -> dict[str, Any]:
         super().complete_snapshot_state(state)
@@ -76,22 +83,38 @@ class EntidadContacto(AggregateRoot[IdEntidadContacto, EntidadExampletate]):
 
     def _marcar_validacion(
         self, validacion: ValidacionEntidadContacto, usuario: IdUsuario
-    ):
+    ) -> None:
         self.validacion = validacion
         self.usuario_validacion = usuario
         self.fecha_validacion = self.Event.create_timestamp()
 
     @command("marcarEntidadContactoCorrecta")
-    def marcar_entidad_contacto_correcta(self, usuario: IdUsuario):
+    def marcar_entidad_contacto_correcta(self, usuario: IdUsuario) -> None:
         self._marcar_validacion(ValidacionEntidadContacto.CORRESPONDE, usuario)
 
     @command("marcarEntidadContactoIncorrecta")
-    def marcar_entidad_contacto_incorrecta(self, usuario: IdUsuario):
+    def marcar_entidad_contacto_incorrecta(self, usuario: IdUsuario) -> None:
         self._marcar_validacion(ValidacionEntidadContacto.NO_CORRESPONDE, usuario)
+
+
+class EntidadContactoView(AggregateView[EntidadContacto]):
+    pass
 
 
 class GetEntidadContactoById(GetById[EntidadContacto, IdEntidadContacto]):
     @classmethod
-    def new(cls, id: IdEntidadContacto | UUID, *_: Any, **__: Any):
+    def new(
+        cls, id: IdEntidadContacto | UUID, *_: Any, **__: Any
+    ) -> "GetEntidadContactoById":
         id = IdEntidadContacto.from_value(id)
-        return super().new(id=id, agg_type=EntidadContacto)
+        return cls(id=id, view=EntidadContactoView)
+
+
+__all__ = [
+    "EntidadContacto",
+    "EntidadExampletate",
+    "EntidadContactoView",
+    "GetEntidadContactoById",
+    "IdEntidadContacto",
+    "ValidacionEntidadContacto",
+]

--- a/src/example/contacto/domain/entidad_contacto.py
+++ b/src/example/contacto/domain/entidad_contacto.py
@@ -69,6 +69,11 @@ class EntidadContacto(AggregateRoot[IdEntidadContacto, EntidadExampletate]):
     def create_id(cls, entidad: IdEntidad, contacto: IdContacto, *_, **__: Any):
         return super().create_id(entidad=entidad, contacto=contacto)
 
+    def complete_snapshot_state(self, state: dict[str, Any]) -> dict[str, Any]:
+        super().complete_snapshot_state(state)
+        state["id_entidad_contacto"] = self.value_id
+        return state
+
     def _marcar_validacion(
         self, validacion: ValidacionEntidadContacto, usuario: IdUsuario
     ):

--- a/src/example/contacto/domain/shared.py
+++ b/src/example/contacto/domain/shared.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any
+from typing import Any, Self
 from uuid import NAMESPACE_URL, uuid5
 
 from hexagonal.domain import ExternalId, IdValueObject, ValueObject
@@ -18,20 +18,20 @@ class TipoEntidad(Enum):
 class ContactoValue(ValueObject[str]):
     tipo: TipoContacto
 
-    def to_id(self):
+    def to_id(self) -> "IdContacto":
         return IdContacto.new(contacto=self)
 
 
 class EntidadValue(ValueObject[str]):
     tipo: TipoEntidad
 
-    def to_id(self):
+    def to_id(self) -> "IdEntidad":
         return IdEntidad.new(entidad=self)
 
 
 class IdContacto(IdValueObject):
     @classmethod
-    def new(cls, *_: Any, contacto: ContactoValue, **__: Any):
+    def new(cls, *_: Any, contacto: ContactoValue, **__: Any) -> Self:
         return cls(
             value=uuid5(
                 NAMESPACE_URL, f"example/{contacto.tipo.value}/{contacto.value}"
@@ -41,7 +41,7 @@ class IdContacto(IdValueObject):
 
 class IdEntidad(IdValueObject):
     @classmethod
-    def new(cls, *_: Any, entidad: EntidadValue, **__: Any):
+    def new(cls, *_: Any, entidad: EntidadValue, **__: Any) -> Self:
         return cls(
             value=uuid5(
                 NAMESPACE_URL, f"entidades/{entidad.tipo.value}/{entidad.value}"
@@ -50,3 +50,14 @@ class IdEntidad(IdValueObject):
 
 
 class IdUsuario(ExternalId): ...
+
+
+__all__ = [
+    "ContactoValue",
+    "EntidadValue",
+    "IdContacto",
+    "IdEntidad",
+    "IdUsuario",
+    "TipoContacto",
+    "TipoEntidad",
+]

--- a/src/example/contacto/ports/drivens.py
+++ b/src/example/contacto/ports/drivens.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Generic
+from typing import Generic, Protocol
 
 from example.contacto.domain.contacto import Contacto
 from example.contacto.domain.entidad import Entidad
@@ -12,7 +12,11 @@ from hexagonal.ports.drivens import (
     IAggregateRepository,
     IBaseInfrastructure,
     IEntityRepository,
+    IReadScopeFactory,
+    IReadScopeRunner,
     IUnitOfWork,
+    IWriteScopeFactory,
+    IWriteScopeRunner,
     TManager,
 )
 
@@ -24,6 +28,35 @@ IEntidadContactoRepository = IAggregateRepository[
 IContactoRepository = IAggregateRepository[TManager, Contacto, IdContacto]
 
 IEntidadRepository = IEntityRepository[TManager, Entidad, IdEntidad]
+
+
+class IContactoWriteScope(Protocol, Generic[TManager]):
+    @property
+    def contacto_repository(self) -> IContactoRepository[TManager]: ...
+
+    @property
+    def entidad_contacto_repository(self) -> IEntidadContactoRepository[TManager]: ...
+
+    @property
+    def entidad_repository(self) -> IEntidadRepository[TManager]: ...
+
+    @property
+    def uow(self) -> IUnitOfWork[TManager]: ...
+
+
+class IContactoWriteScopeProvider(
+    IWriteScopeFactory[IContactoWriteScope[TManager]],
+    IReadScopeFactory[TManager],
+    Protocol,
+    Generic[TManager],
+):
+    @property
+    def write_scope_runner(
+        self,
+    ) -> IWriteScopeRunner[IContactoWriteScope[TManager]]: ...
+
+    @property
+    def read_scope_runner(self) -> IReadScopeRunner[TManager]: ...
 
 
 class IAppContactoInfrastructure(IBaseInfrastructure, Generic[TManager]):

--- a/src/example/database/__init__.py
+++ b/src/example/database/__init__.py
@@ -1,9 +1,5 @@
 from .base import Base
-from .contacto import (
-    Contacto,
-    EstadoValidacionContacto,
-    TipoContacto
-)
+from .contacto import Contacto, EstadoValidacionContacto, TipoContacto
 from .entidad import Afiliado, Entidad, TipoEntidad
 from .entidad_contacto import EntidadContacto, ValidacionContactoEntidad
 

--- a/src/example/database/base.py
+++ b/src/example/database/base.py
@@ -1,7 +1,8 @@
 import os
 
-from hexagonal.adapters.drivens.repository.sqlalchemy.models import metadata
 from sqlalchemy.orm import DeclarativeBase
+
+from hexagonal.adapters.drivens.repository.sqlalchemy.models import metadata
 
 SCHEMA = os.getenv(
     "SCHEMA_NAME",

--- a/src/example/shared/mapper_enum_tables.py
+++ b/src/example/shared/mapper_enum_tables.py
@@ -41,7 +41,7 @@ class MapperEnumTables(Generic[T, E], Infrastructure):
     def _sync(self) -> None:
         """Sincroniza de forma optimista el enum con los registros de la tabla."""
         # Usamos el manager para obtener una conexión y ejecutar los insert necesarios
-        with self.manager.cursor(commit=True) as conn:  # type: ignore
+        with self.manager.cursor(commit=True) as conn:
             # Consultar todos los registros existentes
             stmt = select(self.table_model)
             results = conn.execute(stmt).all()

--- a/src/example/shared/mapper_enum_tables.py
+++ b/src/example/shared/mapper_enum_tables.py
@@ -1,10 +1,11 @@
 from enum import Enum
 from typing import Generic, Mapping, Type, TypeVar
 
-from hexagonal.integrations.sqlalchemy import SQLAlchemyConnectionContextManager
-from hexagonal.application import Infrastructure
 from sqlalchemy import insert, select
 from sqlalchemy.orm import DeclarativeBase
+
+from hexagonal.application import Infrastructure
+from hexagonal.integrations.sqlalchemy import SQLAlchemyConnectionContextManager
 
 T = TypeVar("T", bound=DeclarativeBase)
 E = TypeVar("E", bound=Enum)

--- a/src/hexagonal/adapters/drivens/buses/base/command_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/command_bus.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Type
+from typing import Any, Mapping, Type, cast
 
 from eventsourcing.utils import get_topic
 
@@ -36,14 +36,14 @@ class BaseCommandBus(ICommandBus[TManager], MessageBus[TManager]):
 
     def register_handler(
         self, command_type: Type[TCommand], handler: IMessageHandler[TCommand]
-    ):
+    ) -> None:
         self.verify()
         name = self._get_name(command_type)
         if name in self._handlers:
             raise HandlerAlreadyRegistered(f"Command: {name}")
         self._handlers[name] = handler
 
-    def unregister_handler(self, command_type: Type[TCommand]):
+    def unregister_handler(self, command_type: Type[TCommand]) -> None:
         self.verify()
         name = self._get_name(command_type)
         if name in self._handlers:
@@ -58,7 +58,7 @@ class BaseCommandBus(ICommandBus[TManager], MessageBus[TManager]):
         cmd = (
             command
             if not isinstance(command, Command)
-            else CloudMessage[command.__class__].new(command)  # type: ignore
+            else cast(CloudMessage[TCommand], CloudMessage.new(command))
         )
         if to_outbox:
             self.save_to_outbox(cmd)

--- a/src/hexagonal/adapters/drivens/buses/base/command_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/command_bus.py
@@ -61,7 +61,7 @@ class BaseCommandBus(ICommandBus[TManager], MessageBus[TManager]):
             else CloudMessage[command.__class__].new(command)  # type: ignore
         )
         if to_outbox:
-            self.outbox_repository.save(cmd)
+            self.save_to_outbox(cmd)
         else:
             self.process_command(cmd)
 

--- a/src/hexagonal/adapters/drivens/buses/base/command_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/command_bus.py
@@ -1,10 +1,9 @@
-from typing import Any, Mapping, Type, cast
+from typing import Any, Mapping, Type
 
 from eventsourcing.utils import get_topic
 
 from hexagonal.domain import (
     CloudMessage,
-    Command,
     HandlerAlreadyRegistered,
     HandlerNotRegistered,
     TCommand,
@@ -52,18 +51,16 @@ class BaseCommandBus(ICommandBus[TManager], MessageBus[TManager]):
             raise HandlerNotRegistered(f"Command: {name}")
 
     def dispatch(
-        self, command: TCommand | CloudMessage[TCommand], *, to_outbox: bool = False
+        self,
+        command: CloudMessage[TCommand],
+        *,
+        to_outbox: bool = False,
     ) -> None:
         self.verify()
-        cmd = (
-            command
-            if not isinstance(command, Command)
-            else cast(CloudMessage[TCommand], CloudMessage.new(command))
-        )
         if to_outbox:
-            self.save_to_outbox(cmd)
+            self.save_to_outbox(command)
         else:
-            self.process_command(cmd)
+            self.process_command(command)
 
     def process_command(self, command: CloudMessage[TCommand]) -> None:
         self._process_messages(command)

--- a/src/hexagonal/adapters/drivens/buses/base/event_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/event_bus.py
@@ -21,22 +21,36 @@ logger = logging.getLogger(__name__)
 class HandlerError(Exception):
     def __init__(
         self,
-        evento: CloudMessage[TEvento],
+        evento: CloudMessage[TEvento] | TEvento,
         handler: IMessageHandler[TEvent] | Callable[..., None],
         error: Exception,
-    ):
-        super().__init__(f"""
-Error al Manejar Evento {evento.__class__.__name__}
-    handler: {
-            handler.__class__.__name__  # pyright: ignore[reportUnknownMemberType]
+    ) -> None:
+        handler_name = (
+            handler.__class__.__name__
             if isinstance(handler, IMessageHandler)
             else handler.__name__
-        }   
-    evento: {evento.type}
-    datos: {evento.model_dump_json(indent=2)}
+        )
+        event_name = (
+            evento.__class__.__name__
+            if not isinstance(evento, CloudMessage)
+            else evento.payload.__class__.__name__
+        )
+        event_topic = (
+            evento.TOPIC if not isinstance(evento, CloudMessage) else evento.type
+        )
+        event_dump = (
+            evento.model_dump_json(indent=2)
+            if not isinstance(evento, CloudMessage)
+            else evento.model_dump_json(indent=2)
+        )
+        super().__init__(f"""
+Error al Manejar Evento {event_name}
+    handler: {handler_name}
+    evento: {event_topic}
+    datos: {event_dump}
     error: {error}
     stacktrace: {error.__traceback__}
-        """)  # type: ignore  # noqa: E501
+        """)
 
 
 class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
@@ -62,7 +76,9 @@ class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
                 f"Handler: {obj.__class__}, error: {e}"
             ) from e
 
-    def subscribe(self, event_type: Type[TEvent], handler: IMessageHandler[TEvent]):
+    def subscribe(
+        self, event_type: Type[TEvent], handler: IMessageHandler[TEvent]
+    ) -> None:
         self.verify()
         key_event = self._get_key(event_type)
         handlers = self.handlers.get(key_event, {})
@@ -72,7 +88,9 @@ class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
         handlers[key_handler] = handler
         self.handlers[key_event] = handlers
 
-    def unsubscribe(self, event_type: Type[TEvent], *handlers: IMessageHandler[TEvent]):
+    def unsubscribe(
+        self, event_type: Type[TEvent], *handlers: IMessageHandler[TEvent]
+    ) -> None:
         self.verify()
         key_event = self._get_key(event_type)
         if not handlers:
@@ -91,7 +109,9 @@ class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
         if not list(self.handlers[key_event].values()):
             del self.handlers[key_event]
 
-    def _wait_for(self, event_type: Type[TEvent], handler: Callable[[TEvent], None]):
+    def _wait_for(
+        self, event_type: Type[TEvent], handler: Callable[[TEvent], None]
+    ) -> None:
         name = self._get_key(event_type)
         if name not in self.wait_list:
             self.wait_list[name] = []
@@ -102,7 +122,7 @@ class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
             len(self.wait_list[name]),
         )
 
-    def _handle_wait_list(self, event: TEvento):
+    def _handle_wait_list(self, event: TEvento) -> None:
         event_type = type(event)
         key = self._get_key(event_type)
         logger.debug("    [DEBUG _handle_wait_list] Publishing event type=%s", key)
@@ -115,14 +135,17 @@ class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
             logger.debug("    [DEBUG _handle_wait_list] No handlers registered!")
         while wait_list:
             if self.raise_error:
-                handler = wait_list.pop()
-                handler(event)
+                immediate_handler = wait_list.pop()
+                immediate_handler(event)
             else:
+                queued_handler: Callable[[TEvento], None] | None = None
                 try:
-                    handler = wait_list.pop()
-                    handler(event)
+                    queued_handler = wait_list.pop()
+                    queued_handler(event)
                 except Exception as e:
-                    raise HandlerError(event, handler, e) from e  # type: ignore
+                    if queued_handler is None:
+                        raise
+                    raise HandlerError(event, queued_handler, e) from e
 
     @overload
     def wait_for_publish(
@@ -139,9 +162,10 @@ class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
     ) -> Callable[[Callable[[TEvent], None]], None] | None:
         self.verify()
         if handler:
-            return self._wait_for(event_type, handler)
+            self._wait_for(event_type, handler)
+            return None
 
-        def decorator(func: Callable[[TEvent], None]):
+        def decorator(func: Callable[[TEvent], None]) -> None:
             self._wait_for(event_type, func)
 
         return decorator
@@ -172,4 +196,4 @@ class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
             logger.error(e)
 
     def process_events(self, *events: CloudMessage[TEvent]) -> None:
-        return self._process_messages(*events)
+        self._process_messages(*events)

--- a/src/hexagonal/adapters/drivens/buses/base/event_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/event_bus.py
@@ -52,6 +52,9 @@ class BaseEventBus(IEventBus[TManager], MessageBus[TManager]):
     def _get_key(self, obj: Type[TEvent] | IMessageHandler[TEvent]) -> str:
         if not isinstance(obj, IMessageHandler):
             return get_topic(obj)
+        handler_key = getattr(obj, "handler_key", None)
+        if isinstance(handler_key, str):
+            return handler_key
         try:
             return get_topic(obj.__class__)
         except TopicError as e:

--- a/src/hexagonal/adapters/drivens/buses/base/infrastructure.py
+++ b/src/hexagonal/adapters/drivens/buses/base/infrastructure.py
@@ -16,23 +16,23 @@ class BaseBusInfrastructure(IBusInfrastructure[TManager], InfrastructureGroup):
         event_bus: IEventBus[TManager],
         query_bus: IQueryBus[TManager],
         *args: IBaseInfrastructure,
-    ):
+    ) -> None:
         self._command_bus = command_bus
         self._event_bus = event_bus
         self._query_bus = query_bus
         super().__init__(self._command_bus, self._event_bus, self._query_bus, *args)
 
     @property
-    def command_bus(self):
+    def command_bus(self) -> ICommandBus[TManager]:
         self.verify()
         return self._command_bus
 
     @property
-    def event_bus(self):
+    def event_bus(self) -> IEventBus[TManager]:
         self.verify()
         return self._event_bus
 
     @property
-    def query_bus(self):
+    def query_bus(self) -> IQueryBus[TManager]:
         self.verify()
         return self._query_bus

--- a/src/hexagonal/adapters/drivens/buses/base/message_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/message_bus.py
@@ -9,6 +9,7 @@ from hexagonal.ports.drivens import (
     IOutboxRepository,
     TManager,
 )
+from hexagonal.ports.drivens.scoped import IWriteScopeRunner, TWriteScope
 
 
 class MessageBus(IBaseMessageBus[TManager], Infrastructure):
@@ -19,7 +20,7 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
     ) -> None:
         self._inbox_repository = inbox_repository
         self._outbox_repository = outbox_repository
-        self._write_scope_runner: Any | None = None
+        self._write_scope_runner: IWriteScopeRunner[Any] | None = None
         self._outbox_repository_getter: (
             Callable[[Any], IOutboxRepository[TManager]] | None
         ) = None
@@ -36,8 +37,8 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
     def configure_scope_runtime(
         self,
         *,
-        write_scope_runner: Any | None = None,
-        outbox_repository_getter: Callable[[Any], IOutboxRepository[TManager]]
+        write_scope_runner: IWriteScopeRunner[TWriteScope] | None = None,
+        outbox_repository_getter: Callable[[TWriteScope], IOutboxRepository[TManager]]
         | None = None,
     ) -> None:
         self._write_scope_runner = write_scope_runner
@@ -48,7 +49,6 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
         if self._write_scope_runner is None or self._outbox_repository_getter is None:
             self.outbox_repository.save(*messages)
             return
-
         outbox_repository_getter = self._outbox_repository_getter
 
         scope = self._write_scope_runner.current_write_scope

--- a/src/hexagonal/adapters/drivens/buses/base/message_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/message_bus.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Callable
 
 from hexagonal.application import Infrastructure
 from hexagonal.domain import CloudMessage
@@ -19,6 +19,10 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
     ):
         self._inbox_repository = inbox_repository
         self._outbox_repository = outbox_repository
+        self._write_scope_runner: Any | None = None
+        self._outbox_repository_getter: (
+            Callable[[Any], IOutboxRepository[TManager]] | None
+        ) = None
         super().__init__()
 
     @property
@@ -28,6 +32,33 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
     @property
     def outbox_repository(self) -> IOutboxRepository[TManager]:
         return self._outbox_repository
+
+    def configure_scope_runtime(
+        self,
+        *,
+        write_scope_runner: Any | None = None,
+        outbox_repository_getter: Callable[[Any], IOutboxRepository[TManager]]
+        | None = None,
+    ) -> None:
+        self._write_scope_runner = write_scope_runner
+        self._outbox_repository_getter = outbox_repository_getter
+
+    def save_to_outbox(self, *messages: CloudMessage[Any]) -> None:
+        self.verify()
+        if self._write_scope_runner is None or self._outbox_repository_getter is None:
+            self.outbox_repository.save(*messages)
+            return
+
+        scope = self._write_scope_runner.current_write_scope
+        if scope is not None:
+            self._outbox_repository_getter(scope).save(*messages)
+            return
+
+        self._write_scope_runner.run_in_write_scope(
+            lambda write_scope: self._outbox_repository_getter(write_scope).save(
+                *messages
+            )
+        )
 
     # publish
     def publish_from_outbox(self, limit: int | None = None):

--- a/src/hexagonal/adapters/drivens/buses/base/message_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/message_bus.py
@@ -16,7 +16,7 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
         self,
         inbox_repository: IInboxRepository[TManager],
         outbox_repository: IOutboxRepository[TManager],
-    ):
+    ) -> None:
         self._inbox_repository = inbox_repository
         self._outbox_repository = outbox_repository
         self._write_scope_runner: Any | None = None
@@ -49,19 +49,19 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
             self.outbox_repository.save(*messages)
             return
 
+        outbox_repository_getter = self._outbox_repository_getter
+
         scope = self._write_scope_runner.current_write_scope
         if scope is not None:
-            self._outbox_repository_getter(scope).save(*messages)
+            outbox_repository_getter(scope).save(*messages)
             return
 
         self._write_scope_runner.run_in_write_scope(
-            lambda write_scope: self._outbox_repository_getter(write_scope).save(
-                *messages
-            )
+            lambda write_scope: outbox_repository_getter(write_scope).save(*messages)
         )
 
     # publish
-    def publish_from_outbox(self, limit: int | None = None):
+    def publish_from_outbox(self, limit: int | None = None) -> None:
         self.verify()
         messages = self.outbox_repository.fetch_pending(limit=limit)
         self._publish_messages(*messages)

--- a/src/hexagonal/adapters/drivens/buses/base/query.py
+++ b/src/hexagonal/adapters/drivens/buses/base/query.py
@@ -43,14 +43,14 @@ class QueryBus(IQueryBus[TManager], Infrastructure):
         self,
         query_type: Type[TQuery],
         handler: IQueryHandler[TManager, TQuery, TView],
-    ):
+    ) -> None:
         self.verify()
         name = self._get_name(query_type)
         if name in self.handlers:
             raise HandlerAlreadyRegistered(f"Query: {name}")
         self.handlers[name] = handler
 
-    def unregister_handler(self, query_type: Type[TQuery]):
+    def unregister_handler(self, query_type: Type[TQuery]) -> None:
         self.verify()
         name = self._get_name(query_type)
         if name in self.handlers:

--- a/src/hexagonal/adapters/drivens/buses/base/query.py
+++ b/src/hexagonal/adapters/drivens/buses/base/query.py
@@ -15,6 +15,7 @@ from hexagonal.domain import (
     TView,
 )
 from hexagonal.ports.drivens import IQueryBus, IQueryHandler, TManager
+from hexagonal.ports.drivens.scoped import IReadScopeRunner
 
 
 class QueryBus(IQueryBus[TManager], Infrastructure):
@@ -22,11 +23,11 @@ class QueryBus(IQueryBus[TManager], Infrastructure):
 
     def initialize(self, env: Mapping[str, str]) -> None:
         self.handlers = {}
-        self._read_scope_runner = None
+        self._read_scope_runner: IReadScopeRunner[Any] | None = None
         super().initialize(env)
 
     def configure_read_scope_runtime(
-        self, read_scope_runner: Any | None = None
+        self, read_scope_runner: IReadScopeRunner[Any] | None = None
     ) -> None:
         self._read_scope_runner = read_scope_runner
 

--- a/src/hexagonal/adapters/drivens/buses/base/query.py
+++ b/src/hexagonal/adapters/drivens/buses/base/query.py
@@ -22,7 +22,13 @@ class QueryBus(IQueryBus[TManager], Infrastructure):
 
     def initialize(self, env: Mapping[str, str]) -> None:
         self.handlers = {}
+        self._read_scope_runner = None
         super().initialize(env)
+
+    def configure_read_scope_runtime(
+        self, read_scope_runner: Any | None = None
+    ) -> None:
+        self._read_scope_runner = read_scope_runner
 
     def _get_name(self, query_type: Type[QueryBase[TView]]) -> str:
         return get_topic(query_type)

--- a/src/hexagonal/adapters/drivens/buses/inmemory/command_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/inmemory/command_bus.py
@@ -16,7 +16,7 @@ class InMemoryCommandBus(BaseCommandBus[TManager]):
     def _publish_message(self, message: CloudMessage[TCommand]) -> None:
         return self._process_messages(message)
 
-    def consume(self, limit: int | None = None):
+    def consume(self, limit: int | None = None) -> None:
         return  # No-op for non-queued bus
 
 
@@ -66,5 +66,5 @@ class InMemoryQueueCommandBus(BaseCommandBus[TManager]):
             finally:
                 self.queue.task_done()
 
-    def consume(self, limit: int | None = None):
+    def consume(self, limit: int | None = None) -> None:
         self._worker.start()

--- a/src/hexagonal/adapters/drivens/buses/inmemory/event_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/inmemory/event_bus.py
@@ -15,6 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 class InMemoryEventBus(BaseEventBus[TManager]):
+    def shutdown(self) -> None:
+        return
+
     def _publish_message(self, message: CloudMessage[TEvento]) -> None:
         super()._publish_message(message)
         self._process_messages(message)

--- a/src/hexagonal/adapters/drivens/buses/inmemory/event_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/inmemory/event_bus.py
@@ -25,7 +25,7 @@ class InMemoryEventBus(BaseEventBus[TManager]):
     def publish(self, *events: CloudMessage[TEvent]) -> None:
         return self._publish_messages(*events)
 
-    def consume(self, limit: int | None = None):
+    def consume(self, limit: int | None = None) -> None:
         pass  # No-op for non-queued bus
 
 
@@ -71,5 +71,5 @@ class InMemoryQueueEventBus(BaseEventBus[TManager]):
             finally:
                 self.queue.task_done()
 
-    def consume(self, limit: int | None = None):
+    def consume(self, limit: int | None = None) -> None:
         self._worker.start()

--- a/src/hexagonal/adapters/drivens/mappers.py
+++ b/src/hexagonal/adapters/drivens/mappers.py
@@ -91,8 +91,8 @@ class MessageMapper(Mapper[UUID]):
             getattr(cls, f"upcast_v{from_version}_v{from_version + 1}")(event_state)
             from_version += 1
         if issubclass(cls, AggregateSnapshot):
-            return cls.model_validate(event_state)  # type: ignore[return-value]
-        domain_event = object.__new__(cls)
+            return cast(DomainEventProtocol[UUID], cls.model_validate(event_state))
+        domain_event = cast(DomainEventProtocol[UUID], object.__new__(cls))
         domain_event.__dict__.update(event_state)
         return domain_event
 

--- a/src/hexagonal/adapters/drivens/repository/base/repository.py
+++ b/src/hexagonal/adapters/drivens/repository/base/repository.py
@@ -38,22 +38,19 @@ class BaseRepositoryAdapter(IBaseRepository[TManager], Infrastructure):
         name = self.NAME or self.__class__.__name__.upper()
         env2.update(env)
         self.env = Environment(name, env2)
-        self._attached_to_uow = False
-        self._manager_at_uow: TManager | None = None
+        self._scope_connection_manager: TManager | None = None
         super().initialize(self.env)
 
     def attach_to_unit_of_work(self, uow: IUnitOfWork[TManager]) -> None:
-        self._attached_to_uow = True
-        self._manager_at_uow = uow.connection_manager
+        self._scope_connection_manager = uow.connection_manager
 
     def detach_from_unit_of_work(self) -> None:
-        self._attached_to_uow = False
-        self._manager_at_uow = None
+        self._scope_connection_manager = None
 
     @property
     def connection_manager(self) -> TManager:
-        if self._attached_to_uow and self._manager_at_uow is not None:
-            return self._manager_at_uow
+        if self._scope_connection_manager is not None:
+            return self._scope_connection_manager
         return self._connection_manager
 
 

--- a/src/hexagonal/adapters/drivens/repository/base/unit_of_work.py
+++ b/src/hexagonal/adapters/drivens/repository/base/unit_of_work.py
@@ -1,4 +1,5 @@
-from typing import Mapping
+from types import TracebackType
+from typing import Any, Mapping, cast
 
 from eventsourcing.utils import get_topic
 
@@ -11,7 +12,7 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
         self,
         *repositories: IBaseRepository[TManager],
         connection_manager: TManager,
-    ):
+    ) -> None:
         self._repositories = {get_topic(repo.__class__): repo for repo in repositories}
         self._initialized = False
         self._manager = connection_manager
@@ -27,7 +28,7 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
     def initialized(self) -> bool:
         return self._initialized and super().initialized
 
-    def attach_repo(self, repo: IBaseRepository[TManager]):
+    def attach_repo(self, repo: IBaseRepository[TManager]) -> None:
         topic = get_topic(repo.__class__)
         if topic in self._repositories:
             return
@@ -51,10 +52,10 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
         del self._repositories[topic]
 
     @property
-    def connection_manager(self):
+    def connection_manager(self) -> TManager:
         return self._manager
 
-    def __enter__(self):
+    def __enter__(self) -> "BaseUnitOfWork[TManager]":
         self.verify()
         if self._active:
             return self
@@ -69,7 +70,12 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
         self._active = True
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):  # type: ignore
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self._active = False
         try:
             if exc_type is None:
@@ -82,4 +88,4 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
         finally:
             for repo in self._attached_repositories:
                 repo.detach_from_unit_of_work()
-            self._ctx.__exit__(exc_type, exc_val, exc_tb)  # type: ignore
+            cast(Any, self._ctx).__exit__(exc_type, exc_val, exc_tb)

--- a/src/hexagonal/adapters/drivens/repository/base/unit_of_work.py
+++ b/src/hexagonal/adapters/drivens/repository/base/unit_of_work.py
@@ -20,6 +20,7 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
     def initialize(self, env: Mapping[str, str]) -> None:
         self._initialized = True
         self._active = False
+        self._attached_repositories: list[IBaseRepository[TManager]] = []
         return super().initialize(env)
 
     @property
@@ -32,8 +33,13 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
             return
 
         self._repositories[topic] = repo
-        if self.initialized and self._active:
+        if (
+            self.initialized
+            and self._active
+            and repo.connection_manager is not self._manager
+        ):
             repo.attach_to_unit_of_work(self)
+            self._attached_repositories.append(repo)
 
     def detach_repo(self, repo: IBaseRepository[TManager]) -> None:
         topic = get_topic(repo.__class__)
@@ -54,8 +60,12 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
             return self
         # get connection from manager, the connection is entered yet
         self._ctx = self._manager.start_connection()
+        self._attached_repositories = []
         for repo in self._repositories.values():
+            if repo.connection_manager is self._manager:
+                continue
             repo.attach_to_unit_of_work(self)
+            self._attached_repositories.append(repo)
         self._active = True
         return self
 
@@ -70,6 +80,6 @@ class BaseUnitOfWork(IUnitOfWork[TManager], InfrastructureGroup):
             # Log or handle commit/rollback errors
             raise RuntimeError(f"Failed to finalize transaction: {e}") from e
         finally:
-            for repo in self._repositories.values():
+            for repo in self._attached_repositories:
                 repo.detach_from_unit_of_work()
             self._ctx.__exit__(exc_type, exc_val, exc_tb)  # type: ignore

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/__init__.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/__init__.py
@@ -6,7 +6,7 @@ backends (PostgreSQL, MySQL, SQLite) through SQLAlchemy's abstraction layer.
 """
 
 from .datastore import SQLAlchemyConnectionContextManager, SQLAlchemyDatastore
-from .infrastructure import SQLAlchemyInfrastructure
+from .infrastructure import SQLAlchemyInfrastructure, SQLAlchemyScopeRunner
 from .outbox import (
     SQLAlchemyInboxRepository,
     SQLAlchemyOutboxRepository,
@@ -27,6 +27,7 @@ __all__ = [
     "SQLAlchemyOutboxRepository",
     "SQLAlchemyInboxRepository",
     "SQLAlchemyInfrastructure",
+    "SQLAlchemyScopeRunner",
     "SQLAlchemyPairInboxOutbox",
     "SQLAlchemyEntityRepositoryAdapter",
     "SQLAlchemySearchRepositoryAdapter",

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
@@ -1,7 +1,7 @@
 """SQLAlchemy datastore and connection context manager."""
 
 from collections.abc import Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from typing import Any, Optional
 
 from eventsourcing.utils import strtobool
@@ -38,7 +38,7 @@ class SQLAlchemyDatastore:
         pool_recycle: int = 3600,
         pool_pre_ping: bool = True,
         max_overflow: int = 10,
-    ):
+    ) -> None:
         """Initialize SQLAlchemy datastore.
 
         Args:
@@ -142,7 +142,7 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
     Maintains a current connection reference for transaction coordination.
     """
 
-    def __init__(self, datastore: Optional[SQLAlchemyDatastore] = None):
+    def __init__(self, datastore: Optional[SQLAlchemyDatastore] = None) -> None:
         """Initialize connection context manager.
 
         Args:
@@ -151,7 +151,7 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
         """
         self._datastore = datastore
         self._current_connection: Optional[Connection] = None
-        self._connection_ctx: Optional[Any] = None
+        self._connection_ctx: Optional[AbstractContextManager[Connection]] = None
         self._initialized = datastore is not None
 
     @property
@@ -216,7 +216,7 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
     def create_scoped_manager(self) -> "SQLAlchemyConnectionContextManager":
         return SQLAlchemyConnectionContextManager(self.datastore)
 
-    def start_connection(self):
+    def start_connection(self) -> Any:
         """Start a new connection context.
 
         Returns:

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
@@ -213,6 +213,9 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
         )
         self._initialized = True
 
+    def create_scoped_manager(self) -> "SQLAlchemyConnectionContextManager":
+        return SQLAlchemyConnectionContextManager(self.datastore)
+
     def start_connection(self):
         """Start a new connection context.
 
@@ -280,7 +283,7 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
                 self._current_connection = None
                 conn = self.current_connection
             yield conn
-            if commit:
+            if commit and conn.in_transaction():
                 conn.commit()
         except Exception:
             # Reset connection on error

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/infrastructure.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/infrastructure.py
@@ -1,12 +1,58 @@
 """SQLAlchemy infrastructure grouping."""
 
+import threading
+from typing import Callable, Generic, Mapping, TypeVar
+
 from hexagonal.adapters.drivens.mappers import MessageMapper
-from hexagonal.application import ComposableInfrastructure
+from hexagonal.application import Infrastructure
+from hexagonal.ports.drivens.repository import TResult
 
 from .datastore import SQLAlchemyConnectionContextManager, SQLAlchemyDatastore
 
+TWriteScope = TypeVar("TWriteScope")
+TReadScope = TypeVar("TReadScope")
 
-class SQLAlchemyInfrastructure(ComposableInfrastructure):
+
+class SQLAlchemyScopeRunner(Generic[TWriteScope, TReadScope]):
+    def __init__(
+        self,
+        create_write_scope: Callable[[], TWriteScope],
+        create_read_scope: Callable[[], TReadScope],
+    ):
+        self._create_write_scope = create_write_scope
+        self._create_read_scope = create_read_scope
+        self._local = threading.local()
+
+    def run_in_write_scope(self, work: Callable[[TWriteScope], TResult]) -> TResult:
+        stack: list[TWriteScope] | None = getattr(
+            self._local, "write_scope_stack", None
+        )
+        if stack is None:
+            stack = []
+            self._local.write_scope_stack = stack
+
+        if stack:
+            return work(stack[-1])
+
+        scope = self._create_write_scope()
+        stack.append(scope)
+        try:
+            return work(scope)
+        finally:
+            stack.pop()
+
+    def run_in_read_scope(self, work: Callable[[TReadScope], TResult]) -> TResult:
+        return work(self._create_read_scope())
+
+    @property
+    def current_write_scope(self) -> TWriteScope | None:
+        stack = getattr(self._local, "write_scope_stack", None)
+        if not stack:
+            return None
+        return stack[-1]
+
+
+class SQLAlchemyInfrastructure(Infrastructure):
     """Groups SQLAlchemy connection manager and mapper for dependency injection.
 
     Provides a convenient way to initialize and access the core
@@ -25,15 +71,28 @@ class SQLAlchemyInfrastructure(ComposableInfrastructure):
             datastore: Optional SQLAlchemyDatastore instance.
                       If not provided, connection_manager.initialize() must be called.
         """
+        super().__init__()
         self._datastore = datastore
         self._mapper = mapper
-        self._connection_manager = SQLAlchemyConnectionContextManager(datastore)
-        super().__init__(self._connection_manager)
+        self._env: Mapping[str, str] = {}
+        self._initialized = datastore is not None
+
+    def initialize(self, env: Mapping[str, str]) -> None:
+        self._env = dict(env)
+        self._initialized = True
+
+    @property
+    def datastore(self) -> SQLAlchemyDatastore:
+        if self._datastore is None:
+            raise RuntimeError("Datastore not initialized. Call initialize() first.")
+        return self._datastore
 
     @property
     def connection_manager(self) -> SQLAlchemyConnectionContextManager:
-        """Get the connection context manager."""
-        return self._connection_manager
+        return self.create_connection_manager()
+
+    def create_connection_manager(self) -> SQLAlchemyConnectionContextManager:
+        return SQLAlchemyConnectionContextManager(self.datastore)
 
     @property
     def mapper(self) -> MessageMapper:

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/infrastructure.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/infrastructure.py
@@ -5,7 +5,7 @@ from typing import Callable, Generic, Mapping, TypeVar, cast
 
 from hexagonal.adapters.drivens.mappers import MessageMapper
 from hexagonal.application import Infrastructure
-from hexagonal.ports.drivens.repository import TResult
+from hexagonal.ports.drivens import TResult
 
 from .datastore import SQLAlchemyConnectionContextManager, SQLAlchemyDatastore
 

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/infrastructure.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/infrastructure.py
@@ -1,7 +1,7 @@
 """SQLAlchemy infrastructure grouping."""
 
 import threading
-from typing import Callable, Generic, Mapping, TypeVar
+from typing import Callable, Generic, Mapping, TypeVar, cast
 
 from hexagonal.adapters.drivens.mappers import MessageMapper
 from hexagonal.application import Infrastructure
@@ -18,7 +18,7 @@ class SQLAlchemyScopeRunner(Generic[TWriteScope, TReadScope]):
         self,
         create_write_scope: Callable[[], TWriteScope],
         create_read_scope: Callable[[], TReadScope],
-    ):
+    ) -> None:
         self._create_write_scope = create_write_scope
         self._create_read_scope = create_read_scope
         self._local = threading.local()
@@ -46,7 +46,9 @@ class SQLAlchemyScopeRunner(Generic[TWriteScope, TReadScope]):
 
     @property
     def current_write_scope(self) -> TWriteScope | None:
-        stack = getattr(self._local, "write_scope_stack", None)
+        stack = cast(
+            list[TWriteScope] | None, getattr(self._local, "write_scope_stack", None)
+        )
         if not stack:
             return None
         return stack[-1]
@@ -63,7 +65,7 @@ class SQLAlchemyInfrastructure(Infrastructure):
         self,
         mapper: MessageMapper,
         datastore: SQLAlchemyDatastore | None = None,
-    ):
+    ) -> None:
         """Initialize SQLAlchemy infrastructure.
 
         Args:

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/outbox.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/outbox.py
@@ -229,7 +229,7 @@ class SQLAlchemyOutboxRepository(
                 )
                 conn.execute(stmt)
 
-    def _cursor(self):
+    def _cursor(self) -> Any:
         """Get the current connection for executing statements."""
         return self._connection_manager.cursor()
 
@@ -311,7 +311,7 @@ class SQLAlchemyInboxRepository(
         if create_tables:
             self.create_tables()
 
-    def _cursor(self):
+    def _cursor(self) -> Any:
         """Get the current connection for executing statements."""
         return self.connection_manager.cursor()
 

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/repository.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/repository.py
@@ -89,7 +89,7 @@ class SQLAlchemyEntityRepositoryAdapter(
             raise AggregateNotFound(f"Entity with id {id} not found")
         return entity
 
-    def save(self, entity: TEntity):
+    def save(self, entity: TEntity) -> None:
         """Save an entity to the repository."""
         self.verify()
         with self.connection_manager.cursor() as conn:

--- a/src/hexagonal/adapters/drivens/repository/sqlite/datastore.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlite/datastore.py
@@ -2,7 +2,8 @@
 
 import sqlite3
 from contextlib import contextmanager
-from typing import Callable, Iterator, Literal, Mapping, Optional, TypeVar
+from types import TracebackType
+from typing import Any, Callable, Iterator, Literal, Mapping, Optional, TypeVar
 
 from eventsourcing.utils import strtobool
 
@@ -32,7 +33,7 @@ class SQLiteDatastore(Infrastructure):
         cached_statements: int = 128,
         uri: bool = False,
         autocommit: bool = False,
-    ):
+    ) -> None:
         """Initialize SQLite datastore.
 
         Args:
@@ -127,25 +128,30 @@ class SQLiteDatastore(Infrastructure):
             self._connection.close()
             self._connection = None
 
-    def __enter__(self):
+    def __enter__(self) -> "SQLiteDatastore":
         self._connection = self.get_connection().__enter__()
         self._connection.row_factory = sqlite3.Row
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):  # type: ignore
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self.close()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
 
-def dict_factory(cursor: sqlite3.Cursor, row: sqlite3.Row):
+def dict_factory(cursor: sqlite3.Cursor, row: sqlite3.Row) -> dict[str, Any]:
     fields = [column[0] for column in cursor.description]
     return {key: value for key, value in zip(fields, row, strict=False)}
 
 
 class SQLiteConnectionContextManager(IConnectionManager, Infrastructure):
-    def __init__(self, datastore: SQLiteDatastore | None = None):
+    def __init__(self, datastore: SQLiteDatastore | None = None) -> None:
         self._current_connection: sqlite3.Connection | None = None
         self._setted_datastore: bool = datastore is not None
         if datastore is not None:
@@ -168,7 +174,7 @@ class SQLiteConnectionContextManager(IConnectionManager, Infrastructure):
         self.verify()
         return self._datastore
 
-    def start_connection(self):
+    def start_connection(self) -> Any:
         self._ctx_con = self.datastore.get_connection()
         self._current_connection = self._ctx_con.__enter__()
         return self._ctx_con

--- a/src/hexagonal/adapters/drivens/repository/sqlite/outbox.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlite/outbox.py
@@ -202,7 +202,7 @@ class SQLiteOutboxRepository(
                 [(now, str(mid)) for mid in message_ids],
             )
 
-    def cursor(self):
+    def cursor(self) -> Any:
         return self._connection_manager.datastore.transaction(commit=True)
 
     def mark_as_failed(self, *message_ids: UUID, error: str) -> None:
@@ -243,7 +243,7 @@ class SQLiteInboxRepository(
         "CREATE_TABLES": "False",
     }
 
-    def cursor(self):
+    def cursor(self) -> Any:
         return self._connection_manager.datastore.transaction(commit=True)
 
     def __init__(

--- a/src/hexagonal/adapters/drivens/repository/sqlite/repository.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlite/repository.py
@@ -206,7 +206,7 @@ class SQLiteRepositoryAdapter(
                     timestamp.isoformat(" ", "milliseconds"),
                 )
                 for stored_event, timestamp in stored_events
-            ],  # type: ignore
+            ],
         )
 
     def save(self, aggregate: TAggregate) -> None:

--- a/src/hexagonal/adapters/drivers/app.py
+++ b/src/hexagonal/adapters/drivers/app.py
@@ -1,30 +1,36 @@
 from hexagonal.domain import CloudMessage, TCommand, TEvent
-from hexagonal.ports.drivens import TManager
+from hexagonal.ports.drivens import (
+    IBusInfrastructure,
+    ICommandBus,
+    IEventBus,
+    IQueryBus,
+    TManager,
+)
 from hexagonal.ports.drivers import IBaseApplication, IBusApp
 
 
 class ApplicationProxyAdapter(IBaseApplication[TManager]):
-    def __init__(self, application: IBaseApplication[TManager]):
+    def __init__(self, application: IBaseApplication[TManager]) -> None:
         self._application = application
 
     @property
-    def bus_app(self):
+    def bus_app(self) -> IBusApp[TManager]:
         return self._application.bus_app
 
     @property
-    def bus_infrastructure(self):
+    def bus_infrastructure(self) -> IBusInfrastructure[TManager]:
         return self._application.bus_infrastructure
 
     @property
-    def command_bus(self):
+    def command_bus(self) -> ICommandBus[TManager]:
         return self._application.command_bus
 
     @property
-    def query_bus(self):
+    def query_bus(self) -> IQueryBus[TManager]:
         return self._application.query_bus
 
     @property
-    def event_bus(self):
+    def event_bus(self) -> IEventBus[TManager]:
         return self._application.event_bus
 
     def bootstrap(self, bus_app: IBusApp[TManager]) -> None:
@@ -36,3 +42,6 @@ class ApplicationProxyAdapter(IBaseApplication[TManager]):
         *event_types: type[TEvent],
     ) -> dict[type[TEvent], TEvent | None]:
         return self._application.dispatch_and_wait_events(command, *event_types)
+
+
+__all__ = ["ApplicationProxyAdapter"]

--- a/src/hexagonal/adapters/drivers/app.py
+++ b/src/hexagonal/adapters/drivers/app.py
@@ -1,4 +1,4 @@
-from hexagonal.domain import CloudMessage, TCommand, TEvent
+from hexagonal.domain import CloudMessage, CommandOutcome, TCommand, TEvento
 from hexagonal.ports.drivens import (
     IBusInfrastructure,
     ICommandBus,
@@ -39,8 +39,8 @@ class ApplicationProxyAdapter(IBaseApplication[TManager]):
     def dispatch_and_wait_events(
         self,
         command: CloudMessage[TCommand],
-        *event_types: type[TEvent],
-    ) -> dict[type[TEvent], TEvent | None]:
+        *event_types: type[TEvento],
+    ) -> CommandOutcome[TCommand]:
         return self._application.dispatch_and_wait_events(command, *event_types)
 
 

--- a/src/hexagonal/application/__init__.py
+++ b/src/hexagonal/application/__init__.py
@@ -1,3 +1,6 @@
+from hexagonal.domain import CommandOutcome as ApiCommandResponse
+from hexagonal.domain import EventOutcome as ApiEventResponse
+
 from .api import BaseAPI, GetEvent, TBaseApp
 from .app import Application
 from .bus_app import BusAppGroup, ComposableBusApp
@@ -27,6 +30,8 @@ from .query import (
 from .topics import RegisterTopics
 
 __all__ = [
+    "ApiCommandResponse",
+    "ApiEventResponse",
     "TBaseApp",
     "BaseAPI",
     "GetEvent",

--- a/src/hexagonal/application/__init__.py
+++ b/src/hexagonal/application/__init__.py
@@ -8,6 +8,8 @@ from .handlers import (
     EventHandlerBase,
     MessageHandler,
     QueryHandler,
+    ScopedMessageHandlerProvider,
+    ScopedQueryHandlerProvider,
 )
 from .infrastructure import (
     ComposableInfrastructure,
@@ -35,6 +37,8 @@ __all__ = [
     "EventHandler",
     "MessageHandler",
     "QueryHandler",
+    "ScopedMessageHandlerProvider",
+    "ScopedQueryHandlerProvider",
     "ComposableInfrastructure",
     "Infrastructure",
     "InfrastructureGroup",

--- a/src/hexagonal/application/api.py
+++ b/src/hexagonal/application/api.py
@@ -195,9 +195,7 @@ class BaseAPI(Generic[TBaseApp]):
             self.app.event_bus.wait_for_publish(e, handler)
 
         if to_outbox:
-            self.app.bus_app.uow.attach_repo(self.app.event_bus.outbox_repository)
-            with self.app.bus_app.uow:
-                self.app.event_bus.outbox_repository.save(cloud_message)
+            self.app.event_bus.save_to_outbox(cloud_message)
             self.app.event_bus.publish_from_outbox()
         else:
             self.app.event_bus.publish(cloud_message)

--- a/src/hexagonal/application/api.py
+++ b/src/hexagonal/application/api.py
@@ -1,32 +1,21 @@
 # mypy: disable-error-code="misc"
 import time
 from enum import Enum
-from typing import (
-    Any,
-    Dict,
-    Generic,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    overload,
-)
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, TypeVar
 from uuid import UUID
 
 from eventsourcing.utils import SupportsTopic, get_topic, register_topic
-from pydantic import Field
 
 from hexagonal.domain import (
     CloudMessage,
     Command,
-    Inmutable,
+    CommandOutcome,
+    EventOutcome,
     QueryOne,
     TCommand,
-    TEvent,
     TEvento,
 )
+from hexagonal.domain.base import TEvent
 from hexagonal.ports.drivens import TAggregate
 from hexagonal.ports.drivers import IBaseApplication
 
@@ -34,58 +23,6 @@ from .app import GetEvent
 from .query import AggregateView
 
 TBaseApp = TypeVar("TBaseApp", bound=IBaseApplication[Any])
-
-
-class ApiCommandResponse(Inmutable, Generic[TCommand]):
-    command: CloudMessage[TCommand]
-    events: Dict[Type[TEvento], TEvento | None] = Field(default_factory=lambda: {})
-    has_events: bool = True
-
-    @overload
-    def get(
-        self, event_type: Type[TEvent], *, raise_error: Literal[True] = True
-    ) -> TEvent: ...
-
-    @overload
-    def get(
-        self, event_type: Type[TEvent], *, raise_error: Literal[False]
-    ) -> Optional[TEvent]: ...
-
-    def get(
-        self, event_type: Type[TEvent], *, raise_error: bool = True
-    ) -> Optional[TEvent]:
-        event = self.events.get(event_type)  # type: ignore
-        if event is None and raise_error:
-            raise KeyError(f"Event {event_type} not found in response")
-        elif not isinstance(event, event_type):
-            raise TypeError(f"Event {event_type} is not of type {event_type}")
-        return event
-
-
-class ApiEventResponse(Inmutable):
-    evento: CloudMessage[TEvento]
-    events: Dict[Type[TEvento], TEvento | None] = Field(default_factory=lambda: {})
-    has_events: bool = True
-
-    @overload
-    def get(
-        self, event_type: Type[TEvent], *, raise_error: Literal[True] = True
-    ) -> TEvent: ...
-
-    @overload
-    def get(
-        self, event_type: Type[TEvent], *, raise_error: Literal[False]
-    ) -> Optional[TEvent]: ...
-
-    def get(
-        self, event_type: Type[TEvent], *, raise_error: bool = True
-    ) -> Optional[TEvent]:
-        event = self.events.get(event_type)  # type: ignore
-        if event is None and raise_error:
-            raise KeyError(f"Event {event_type} not found in response")
-        elif not isinstance(event, event_type):
-            raise TypeError(f"Event {event_type} is not of type {event_type}")
-        return event
 
 
 class BaseAPI(Generic[TBaseApp]):
@@ -137,12 +74,12 @@ class BaseAPI(Generic[TBaseApp]):
         default_events: Optional[List[Type[TEvento]]] = None,
         to_outbox: bool = False,
         **kwargs: Any,
-    ) -> ApiCommandResponse[TCommand]:
+    ) -> CommandOutcome[TCommand]:
         """Dispatch a command and optionally await events before returning."""
         cloud_message = CloudMessage[type(command)].new(command, **kwargs)
         if to_outbox:
             self.app.command_bus.dispatch(cloud_message, to_outbox=to_outbox)
-            return ApiCommandResponse(command=cloud_message, has_events=False)
+            return CommandOutcome(command=cloud_message, events={}, has_events=False)
 
         tracked_events: set[Type[TEvento]] = set()
         events = events or []
@@ -156,7 +93,7 @@ class BaseAPI(Generic[TBaseApp]):
             self.app.event_bus.wait_for_publish(e, handler)
 
         self.app.command_bus.dispatch(cloud_message)
-        return ApiCommandResponse(
+        return CommandOutcome(
             command=cloud_message,
             events={event: wrapper.event for event, wrapper in awaited.items()},
         )
@@ -172,14 +109,14 @@ class BaseAPI(Generic[TBaseApp]):
 
     def publish_and_wait(
         self,
-        event: TEvento,
+        event: TEvent,
         wait: float | None = None,
         *,
         events: Optional[List[Type[TEvento]]] = None,
         default_events: Optional[List[Type[TEvento]]] = None,
         to_outbox: bool = True,
         **kwargs: Any,
-    ) -> ApiEventResponse:
+    ) -> EventOutcome[TEvent]:
         """Publish an event and optionally await other events before returning."""
         cloud_message = CloudMessage[type(event)].new(event, **kwargs)
 
@@ -202,10 +139,10 @@ class BaseAPI(Generic[TBaseApp]):
 
         if wait is not None:
             time.sleep(wait)
-        return ApiEventResponse(
-            evento=cloud_message,
+        return EventOutcome(
+            event=cloud_message,
             events={event: wrapper.event for event, wrapper in awaited.items()},
         )
 
 
-__all__ = ["ApiCommandResponse", "ApiEventResponse", "BaseAPI", "GetEvent", "TBaseApp"]
+__all__ = ["CommandOutcome", "EventOutcome", "BaseAPI", "GetEvent", "TBaseApp"]

--- a/src/hexagonal/application/api.py
+++ b/src/hexagonal/application/api.py
@@ -121,7 +121,7 @@ class BaseAPI(Generic[TBaseApp]):
         self._app = app
         self.topics = self.Events.get_topics() + self.Commands.get_topics()
 
-    def register_topics(self):
+    def register_topics(self) -> None:
         for topic_name, topic in self.topics:
             register_topic(topic_name, topic)
 
@@ -206,3 +206,6 @@ class BaseAPI(Generic[TBaseApp]):
             evento=cloud_message,
             events={event: wrapper.event for event, wrapper in awaited.items()},
         )
+
+
+__all__ = ["ApiCommandResponse", "ApiEventResponse", "BaseAPI", "GetEvent", "TBaseApp"]

--- a/src/hexagonal/application/app.py
+++ b/src/hexagonal/application/app.py
@@ -30,10 +30,6 @@ class Application(IBaseApplication[TManager]):
         bus_infrastructure.verify()
         self._bus_infrastructure = bus_infrastructure
         self._bus_app = bus_app
-        self._bus_app.uow.attach_repo(self.event_bus.inbox_repository)
-        self._bus_app.uow.attach_repo(self.event_bus.outbox_repository)
-        self._bus_app.uow.attach_repo(self.command_bus.inbox_repository)
-        self._bus_app.uow.attach_repo(self.command_bus.outbox_repository)
         self.bootstrap(self._bus_app)
 
     @property

--- a/src/hexagonal/application/app.py
+++ b/src/hexagonal/application/app.py
@@ -1,6 +1,7 @@
-from typing import Dict, Generic, Type
+from typing import Generic, Type
 
-from hexagonal.domain import CloudMessage, TCommand, TEvent
+from hexagonal.domain import CloudMessage, CommandOutcome, TCommand, TEvent
+from hexagonal.domain.base import TEvento
 from hexagonal.ports.drivens import (
     IBusInfrastructure,
     ICommandBus,
@@ -62,12 +63,17 @@ class Application(IBaseApplication[TManager]):
     def dispatch_and_wait_events(
         self,
         command: CloudMessage[TCommand],
-        *event_types: Type[TEvent],
-    ) -> Dict[Type[TEvent], TEvent | None]:
-        handlers: list[tuple[Type[TEvent], GetEvent[TEvent]]] = [
-            (event_type, GetEvent[TEvent]()) for event_type in event_types
-        ]
-        for event_type, handler in handlers:
+        *event_types: Type[TEvento],
+    ) -> CommandOutcome[TCommand]:
+        handlers: dict[Type[TEvento], GetEvent[TEvento]] = {}
+        for event_type in event_types:
+            handler = GetEvent[TEvento]()
+            handlers[event_type] = handler
             self.event_bus.wait_for_publish(event_type, handler)
         self.command_bus.dispatch(command)
-        return {event_type: handler.event for event_type, handler in handlers}
+        return CommandOutcome(
+            command=command,
+            events={
+                event_type: handler.event for event_type, handler in handlers.items()
+            },
+        )

--- a/src/hexagonal/application/app.py
+++ b/src/hexagonal/application/app.py
@@ -14,10 +14,10 @@ from hexagonal.ports.drivers import IBaseApplication, IBusApp
 class GetEvent(Generic[TEvent]):
     event: TEvent | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.event = None
 
-    def __call__(self, event: TEvent):
+    def __call__(self, event: TEvent) -> None:
         self.event = event
 
 
@@ -26,7 +26,7 @@ class Application(IBaseApplication[TManager]):
         self,
         bus_app: IBusApp[TManager],
         bus_infrastructure: IBusInfrastructure[TManager],
-    ):
+    ) -> None:
         bus_infrastructure.verify()
         self._bus_infrastructure = bus_infrastructure
         self._bus_app = bus_app
@@ -64,8 +64,9 @@ class Application(IBaseApplication[TManager]):
         command: CloudMessage[TCommand],
         *event_types: Type[TEvent],
     ) -> Dict[Type[TEvent], TEvent | None]:
-        handlers = [(event_type, GetEvent[event_type]()) for event_type in event_types]  # type: ignore
-        # type: ignore
+        handlers: list[tuple[Type[TEvent], GetEvent[TEvent]]] = [
+            (event_type, GetEvent[TEvent]()) for event_type in event_types
+        ]
         for event_type, handler in handlers:
             self.event_bus.wait_for_publish(event_type, handler)
         self.command_bus.dispatch(command)

--- a/src/hexagonal/application/bus_app.py
+++ b/src/hexagonal/application/bus_app.py
@@ -27,6 +27,8 @@ class ComposableBusApp(IBusApp[TManager]):
 
     @property
     def uow(self) -> IUnitOfWork[TManager]:
+        # Compatibility shim while application wiring migrates away from a
+        # singleton write UoW. Scoped execution should use handler providers.
         return self._bus_app.uow
 
     def __or__(self, other: IBusApp[TManager]) -> "ComposableBusApp[TManager]":
@@ -54,6 +56,8 @@ class BusAppGroup(ComposableBusApp[TManager]):
 
     @property
     def uow(self) -> IUnitOfWork[TManager]:
+        # Compatibility shim while provider-based registration replaces all
+        # remaining singleton-UoW call sites.
         return self._uow
 
     @property

--- a/src/hexagonal/application/handlers.py
+++ b/src/hexagonal/application/handlers.py
@@ -20,9 +20,9 @@ from hexagonal.ports.drivens import (
     ISearchRepository,
     IUnitOfWork,
     IUseCase,
+    IWriteScopeRunner,
     TManager,
     TRepository,
-    IWriteScopeRunner,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/hexagonal/application/handlers.py
+++ b/src/hexagonal/application/handlers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Generic, Iterable
+from typing import Any, Callable, Generic, Iterable, Protocol, TypeVar
 
 from hexagonal.domain import (
     CloudMessage,
@@ -25,6 +25,62 @@ from hexagonal.ports.drivens import (
 
 logger = logging.getLogger(__name__)
 
+TWriteScope = TypeVar("TWriteScope")
+TReadScope = TypeVar("TReadScope")
+
+
+class IScopedMessageHandlerProvider(Protocol[TMessagePayloadType, TWriteScope]):
+    def create(self, scope: TWriteScope) -> IMessageHandler[TMessagePayloadType]: ...
+
+
+class ScopedMessageHandlerProvider(
+    IMessageHandler[TMessagePayloadType],
+    Generic[TMessagePayloadType, TWriteScope],
+):
+    def __init__(
+        self,
+        write_scope_runner: Any,
+        factory: Callable[[TWriteScope], IMessageHandler[TMessagePayloadType]],
+    ) -> None:
+        self._write_scope_runner = write_scope_runner
+        self._factory = factory
+        self.handler_key = f"{self.__class__.__name__}:{id(self)}"
+
+    def create(self, scope: TWriteScope) -> IMessageHandler[TMessagePayloadType]:
+        return self._factory(scope)
+
+    def handle_message(self, message: CloudMessage[TMessagePayloadType]) -> None:
+        self._write_scope_runner.run_in_write_scope(
+            lambda scope: self.create(scope).handle_message(message)
+        )
+
+    def get_use_case(self, message: TMessagePayloadType) -> IUseCase:
+        raise NotImplementedError(
+            "Scoped providers materialize handlers inside a scope"
+        )
+
+
+class ScopedQueryHandlerProvider(
+    IQueryHandler[TManager, TQuery, TView],
+    Generic[TManager, TQuery, TView, TReadScope],
+):
+    def __init__(
+        self,
+        read_scope_runner: Any,
+        factory: Callable[[TReadScope], IQueryHandler[TManager, TQuery, TView]],
+    ) -> None:
+        self._read_scope_runner = read_scope_runner
+        self._factory = factory
+
+    @property
+    def repository(self) -> ISearchRepository[TManager, TQuery, TView]:
+        raise RuntimeError("Scoped query providers do not expose a stable repository")
+
+    def get(self, query: TQuery) -> QueryResults[TView]:
+        return self._read_scope_runner.run_in_read_scope(
+            lambda scope: self._factory(scope).get(query)
+        )
+
 
 class MessageHandler(
     IMessageHandler[TMessagePayloadType], Generic[TMessagePayloadType, TRepository]
@@ -44,9 +100,14 @@ class MessageHandler(
         self.uow = uow
         self._repository = repository
         self._query_bus = query_bus
-        if repository is not None:
+        if (
+            repository is not None
+            and repository.connection_manager is not self.uow.connection_manager
+        ):
             self.uow.attach_repo(repository)
         for repository in repositories:
+            if repository.connection_manager is self.uow.connection_manager:
+                continue
             self.uow.attach_repo(repository)
 
     @property
@@ -68,7 +129,7 @@ class MessageHandler(
             if not events:
                 return
             messages = [message.derive(event, **message.metadata) for event in events]
-            self.event_bus.outbox_repository.save(*messages)
+            self.event_bus.save_to_outbox(*messages)
         return self.event_bus.publish_from_outbox()
 
 
@@ -133,4 +194,5 @@ class QueryHandler(IQueryHandler[TManager, TQuery, TView]):
 
     def get(self, query: TQuery) -> QueryResults[TView]:
         results = self.repository.search(query)
-        return QueryResults[TView].new(items=results, limit=len(results))
+        items = list(results)
+        return QueryResults[TView].new(items=items, limit=len(items))

--- a/src/hexagonal/application/handlers.py
+++ b/src/hexagonal/application/handlers.py
@@ -16,21 +16,26 @@ from hexagonal.ports.drivens import (
     IMessageHandler,
     IQueryBus,
     IQueryHandler,
+    IReadScopeRunner,
     ISearchRepository,
     IUnitOfWork,
     IUseCase,
     TManager,
     TRepository,
+    IWriteScopeRunner,
 )
 
 logger = logging.getLogger(__name__)
 
 TWriteScope = TypeVar("TWriteScope")
 TReadScope = TypeVar("TReadScope")
+TWriteScope_contra = TypeVar("TWriteScope_contra", contravariant=True)
 
 
-class IScopedMessageHandlerProvider(Protocol[TMessagePayloadType, TWriteScope]):
-    def create(self, scope: TWriteScope) -> IMessageHandler[TMessagePayloadType]: ...
+class IScopedMessageHandlerProvider(Protocol[TMessagePayloadType, TWriteScope_contra]):
+    def create(
+        self, scope: TWriteScope_contra
+    ) -> IMessageHandler[TMessagePayloadType]: ...
 
 
 class ScopedMessageHandlerProvider(
@@ -39,7 +44,7 @@ class ScopedMessageHandlerProvider(
 ):
     def __init__(
         self,
-        write_scope_runner: Any,
+        write_scope_runner: IWriteScopeRunner[TWriteScope],
         factory: Callable[[TWriteScope], IMessageHandler[TMessagePayloadType]],
     ) -> None:
         self._write_scope_runner = write_scope_runner
@@ -66,7 +71,7 @@ class ScopedQueryHandlerProvider(
 ):
     def __init__(
         self,
-        read_scope_runner: Any,
+        read_scope_runner: IReadScopeRunner[TReadScope],
         factory: Callable[[TReadScope], IQueryHandler[TManager, TQuery, TView]],
     ) -> None:
         self._read_scope_runner = read_scope_runner
@@ -130,7 +135,7 @@ class MessageHandler(
                 return
             messages = [message.derive(event, **message.metadata) for event in events]
             self.event_bus.save_to_outbox(*messages)
-        return self.event_bus.publish_from_outbox()
+        self.event_bus.publish_from_outbox()
 
 
 class EventHandlerBase(MessageHandler[TEvent, TRepository]):
@@ -143,7 +148,7 @@ class EventHandlerBase(MessageHandler[TEvent, TRepository]):
             self.event_handler = event_handler
             self.event = event
 
-        def execute(self):
+        def execute(self) -> Iterable[TEvento]:
             evento = self.event_handler.handle(self.event)
             return evento
 
@@ -167,7 +172,7 @@ class CommandHandlerBase(MessageHandler[TCommand, TRepository]):
             self.command_handler = command_handler
             self.command = command
 
-        def execute(self):
+        def execute(self) -> Iterable[TEvento]:
             evento = self.command_handler.execute(self.command)
             return evento
 

--- a/src/hexagonal/application/infrastructure.py
+++ b/src/hexagonal/application/infrastructure.py
@@ -7,7 +7,7 @@ logger = getLogger(__name__)
 
 
 class ComposableInfrastructure(IBaseInfrastructure):
-    def __init__(self, infrastructure: IBaseInfrastructure):
+    def __init__(self, infrastructure: IBaseInfrastructure) -> None:
         self.infrastructure = infrastructure
 
     def initialize(self, env: Mapping[str, str]) -> None:
@@ -35,7 +35,7 @@ class ComposableInfrastructure(IBaseInfrastructure):
 
 
 class InfrastructureGroup(ComposableInfrastructure):
-    def __init__(self, *infrastructures: IBaseInfrastructure):
+    def __init__(self, *infrastructures: IBaseInfrastructure) -> None:
         self.infrastructures = list(infrastructures)
 
     def initialize(self, env: Mapping[str, str]) -> None:
@@ -52,7 +52,7 @@ class InfrastructureGroup(ComposableInfrastructure):
 
 
 class Infrastructure(ComposableInfrastructure):
-    def __init__(self):
+    def __init__(self) -> None:
         self._initialized = False
 
     def initialize(self, env: Mapping[str, str]) -> None:

--- a/src/hexagonal/application/query.py
+++ b/src/hexagonal/application/query.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, List, Mapping
+from typing import Any, Generic, List, Mapping, cast
 
 from hexagonal.domain import (
     AggregateView,
@@ -30,21 +30,21 @@ class SearchAggregateRepository(
         self,
         repo: IAggregateRepository[TManager, TAggregate, TIdEntity]
         | IEntityRepository[TManager, TEntity, TIdEntity],
-    ):
+    ) -> None:
         self._repo = repo
 
     def search(
         self, query: GetById[TAggregate | TEntity, TIdEntity]
     ) -> List[AggregateView[TAggregate | TEntity]]:
         aggregate = self._repo.get(query.id)
-        return [AggregateView[type(aggregate)].new(aggregate)]
+        return [cast(AggregateView[TAggregate | TEntity], AggregateView.new(aggregate))]
 
     ## decorate methods from IAggregateRepository to pass through initialization ##
     def initialize(self, env: Mapping[str, str]) -> None:
         self._repo.initialize(env)
 
     @property
-    def initialized(self):
+    def initialized(self) -> bool:
         return self._repo.initialized
 
     @property
@@ -70,16 +70,30 @@ class GetByIdHandler(
         self,
         agg_repo: IAggregateRepository[TManager, TAggregate, TIdEntity]
         | IEntityRepository[TManager, TEntity, TIdEntity],
-    ):
+    ) -> None:
         search = SearchAggregateRepository(agg_repo)
         super().__init__(search)
 
 
 class GetAggregateByIdHandler(GetByIdHandler[TManager, TIdEntity, TAggregate, Any]):
-    def __init__(self, agg_repo: IAggregateRepository[TManager, TAggregate, TIdEntity]):
+    def __init__(
+        self, agg_repo: IAggregateRepository[TManager, TAggregate, TIdEntity]
+    ) -> None:
         super().__init__(agg_repo)
 
 
 class GetEntityByIdHandler(GetByIdHandler[TManager, TIdEntity, Any, TEntity]):
-    def __init__(self, entity_repo: IEntityRepository[TManager, TEntity, TIdEntity]):
+    def __init__(
+        self, entity_repo: IEntityRepository[TManager, TEntity, TIdEntity]
+    ) -> None:
         super().__init__(entity_repo)
+
+
+__all__ = [
+    "AggregateView",
+    "GetById",
+    "GetAggregateByIdHandler",
+    "GetByIdHandler",
+    "GetEntityByIdHandler",
+    "SearchAggregateRepository",
+]

--- a/src/hexagonal/application/query.py
+++ b/src/hexagonal/application/query.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, List, Mapping, cast
+from typing import Any, Generic, List, Mapping
 
 from hexagonal.domain import (
     AggregateView,
@@ -37,7 +37,9 @@ class SearchAggregateRepository(
         self, query: GetById[TAggregate | TEntity, TIdEntity]
     ) -> List[AggregateView[TAggregate | TEntity]]:
         aggregate = self._repo.get(query.id)
-        return [cast(AggregateView[TAggregate | TEntity], AggregateView.new(aggregate))]
+        return [
+            AggregateView[type(aggregate)].new(aggregate)  # type: ignore
+        ]  # no cambiar los test se rompen
 
     ## decorate methods from IAggregateRepository to pass through initialization ##
     def initialize(self, env: Mapping[str, str]) -> None:

--- a/src/hexagonal/application/topics.py
+++ b/src/hexagonal/application/topics.py
@@ -12,12 +12,12 @@ class RegisterTopics:
 
     def __init__(
         self, *topics: TRegistableTopics | "RegisterTopics", clear: bool = True
-    ):
+    ) -> None:
         if clear:
             self.topics.clear()
         self.topics += list(topics)
 
-    def __call__(self):
+    def __call__(self) -> None:
         self.apply()
 
     @classmethod
@@ -30,7 +30,7 @@ class RegisterTopics:
             raise ValueError(f"Invalid topic: {topic}")
 
     @classmethod
-    def apply(cls):
+    def apply(cls) -> None:
         for topic, obj in [cls._reduce(topic) for topic in cls.topics]:
             register_topic(topic, obj)
 
@@ -41,5 +41,5 @@ class RegisterTopics:
         return RegisterTopics(*(self.topics + other.topics))
 
     @classmethod
-    def register(cls, *topics: TRegistableTopics | "RegisterTopics"):
+    def register(cls, *topics: TRegistableTopics | "RegisterTopics") -> None:
         cls.topics += list(topics)

--- a/src/hexagonal/domain/__init__.py
+++ b/src/hexagonal/domain/__init__.py
@@ -46,6 +46,7 @@ from .exceptions import (
     InfrastructureNotInitialized,
 )
 from .queries import AggregateView, GetById
+from .responses import CommandOutcome, EventOutcome
 
 __all__ = [
     "ExternalId",
@@ -91,4 +92,6 @@ __all__ = [
     "TEntity",
     "QueryOne",
     "QueryBase",
+    "EventOutcome",
+    "CommandOutcome",
 ]

--- a/src/hexagonal/domain/aggregate.py
+++ b/src/hexagonal/domain/aggregate.py
@@ -90,13 +90,13 @@ class AggregateSnapshot(Inmutable, CanSnapshotAggregate[UUID], Generic[TSnapshot
             aggregate_state.pop("_id")
             aggregate_state.pop("_version")
             aggregate_state.pop("_pending_events")
-        dict_snap = dict(
-            originator_id=aggregate.id,  # type: ignore[call-arg]
-            originator_version=aggregate.version,  # pyright: ignore[reportCallIssue]
-            timestamp=cls.create_timestamp(),  # pyright: ignore[reportCallIssue]
-            topic=get_topic(type(aggregate)),  # type: ignore[call-arg]
-            state=aggregate_state,  # pyright: ignore[reportCallIssue]
-        )
+        dict_snap = {
+            "originator_id": aggregate.id,
+            "originator_version": aggregate.version,
+            "timestamp": cls.create_timestamp(),
+            "topic": get_topic(type(aggregate)),
+            "state": aggregate_state,
+        }
         return cls.model_validate(dict_snap)
 
 
@@ -131,7 +131,7 @@ class AggregateRoot(BaseAggregate[UUID], Generic[TIdEntity, TSnapshotState]):
                     cls.Snapshot = AggregateSnapshot[state_type]  # type: ignore[valid-type]
 
     @classmethod
-    def create_id(cls, *args: Any, **kwargs: Any):
+    def create_id(cls, *args: Any, **kwargs: Any) -> UUID:
         return cls._id_type.new(*args, **kwargs).value
 
     @property

--- a/src/hexagonal/domain/aggregate.py
+++ b/src/hexagonal/domain/aggregate.py
@@ -90,11 +90,11 @@ class AggregateSnapshot(Inmutable, CanSnapshotAggregate[UUID], Generic[TSnapshot
             aggregate_state.pop("_id")
             aggregate_state.pop("_version")
             aggregate_state.pop("_pending_events")
-        dict_snap = {
+        dict_snap: dict[str, Any] = {
             "originator_id": aggregate.id,
             "originator_version": aggregate.version,
             "timestamp": cls.create_timestamp(),
-            "topic": get_topic(type(aggregate)),
+            "topic": get_topic(type(aggregate)),  # pyright: ignore
             "state": aggregate_state,
         }
         return cls.model_validate(dict_snap)
@@ -132,7 +132,7 @@ class AggregateRoot(BaseAggregate[UUID], Generic[TIdEntity, TSnapshotState]):
 
     @classmethod
     def create_id(cls, *args: Any, **kwargs: Any) -> UUID:
-        return cls._id_type.new(*args, **kwargs).value
+        return cls._id_type.new(*args, **kwargs).value  # type: ignore
 
     @property
     def value_id(self) -> TIdEntity:

--- a/src/hexagonal/domain/aggregate.py
+++ b/src/hexagonal/domain/aggregate.py
@@ -132,7 +132,7 @@ class AggregateRoot(BaseAggregate[UUID], Generic[TIdEntity, TSnapshotState]):
 
     @classmethod
     def create_id(cls, *args: Any, **kwargs: Any) -> UUID:
-        return cls._id_type.new(*args, **kwargs).value  # type: ignore
+        return cls._id_type.new(*args, **kwargs).value
 
     @property
     def value_id(self) -> TIdEntity:

--- a/src/hexagonal/domain/base.py
+++ b/src/hexagonal/domain/base.py
@@ -31,7 +31,7 @@ class HasTopic:
             set_topic = actual_topic
         else:
             set_topic = f"{base_topic}{'.' if base_topic != '' else ''}{new_topic}"
-        cls.TOPIC = set_topic
+        cls.TOPIC = set_topic  # pyright: ignore[reportConstantRedefinition]
 
 
 class Inmutable(BaseModel):

--- a/src/hexagonal/domain/base.py
+++ b/src/hexagonal/domain/base.py
@@ -13,7 +13,9 @@ from uuid6 import uuid7
 class HasTopic:
     TOPIC: ClassVar[str] = ""
 
-    def __init_subclass__(cls, *, topic_suffix: Optional[str] = None, **kwargs: Any):
+    def __init_subclass__(
+        cls, *, topic_suffix: Optional[str] = None, **kwargs: Any
+    ) -> None:
         # Extraemos nuestro argumento para no pasárselo a Pydantic
         super().__init_subclass__(**kwargs)  # aquí Pydantic recibe sólo lo suyo
         new_topic = topic_suffix or cls.__name__
@@ -29,7 +31,7 @@ class HasTopic:
             set_topic = actual_topic
         else:
             set_topic = f"{base_topic}{'.' if base_topic != '' else ''}{new_topic}"
-        cls.TOPIC = set_topic  # type: ignore
+        cls.TOPIC = set_topic
 
 
 class Inmutable(BaseModel):
@@ -150,7 +152,7 @@ class QueryResults(Inmutable, Generic[TView], FactoryMethod):
     next_cursor: Optional[str] = None
     prev_cursor: Optional[str] = None
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.items)
 
     @classmethod
@@ -160,7 +162,7 @@ class QueryResults(Inmutable, Generic[TView], FactoryMethod):
         limit: int,
         next_cursor: Optional[str] = None,
         prev_cursor: Optional[str] = None,
-    ):
+    ) -> Self:
         return cls(
             items=items, limit=limit, next_cursor=next_cursor, prev_cursor=prev_cursor
         )
@@ -170,7 +172,7 @@ class QueryResult(Inmutable, Generic[TView], FactoryMethod):
     item: TView
 
     @classmethod
-    def new(cls, item: TView):
+    def new(cls, item: TView) -> Self:
         return cls(item=item)
 
 

--- a/src/hexagonal/domain/queries.py
+++ b/src/hexagonal/domain/queries.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Type
+from typing import Any, Generic, Type, cast
 
 from .aggregate import TAggregateOrEntity, TIdEntity
 from .base import QueryOne, ValueObject
@@ -13,5 +13,10 @@ class GetById(
     id: TIdEntity
 
     @classmethod
-    def new(cls, id: TIdEntity, agg_type: Type[TAggregateOrEntity], *_: Any, **__: Any):
-        return cls(id=id, view=AggregateView[agg_type])  # type: ignore
+    def new(
+        cls, id: TIdEntity, agg_type: Type[TAggregateOrEntity], *_: Any, **__: Any
+    ) -> "GetById[TAggregateOrEntity, TIdEntity]":
+        return cls(
+            id=id,
+            view=cast(type[AggregateView[TAggregateOrEntity]], AggregateView),
+        )

--- a/src/hexagonal/domain/responses.py
+++ b/src/hexagonal/domain/responses.py
@@ -1,0 +1,58 @@
+# mypy: disable-error-code="misc"
+from typing import Dict, Generic, Literal, Optional, Type, overload
+
+from pydantic import Field
+
+from hexagonal.domain import CloudMessage, Inmutable, TCommand, TEvent, TEvento
+
+
+class CommandOutcome(Inmutable, Generic[TCommand]):
+    command: CloudMessage[TCommand]
+    events: Dict[Type[TEvento], TEvento | None] = Field(default_factory=lambda: {})
+    has_events: bool = True
+
+    @overload
+    def get(
+        self, event_type: Type[TEvent], *, raise_error: Literal[True] = True
+    ) -> TEvent: ...
+
+    @overload
+    def get(
+        self, event_type: Type[TEvent], *, raise_error: Literal[False]
+    ) -> Optional[TEvent]: ...
+
+    def get(
+        self, event_type: Type[TEvent], *, raise_error: bool = True
+    ) -> Optional[TEvent]:
+        event = self.events.get(event_type)  # type: ignore
+        if event is None and raise_error:
+            raise KeyError(f"Event {event_type} not found in response")
+        elif not isinstance(event, event_type):
+            raise TypeError(f"Event {event_type} is not of type {event_type}")
+        return event
+
+
+class EventOutcome(Inmutable, Generic[TEvent]):
+    event: CloudMessage[TEvent]
+    events: Dict[Type[TEvento], TEvento | None] = Field(default_factory=lambda: {})
+    has_events: bool = True
+
+    @overload
+    def get(
+        self, event_type: Type[TEvent], *, raise_error: Literal[True] = True
+    ) -> TEvent: ...
+
+    @overload
+    def get(
+        self, event_type: Type[TEvent], *, raise_error: Literal[False]
+    ) -> Optional[TEvent]: ...
+
+    def get(
+        self, event_type: Type[TEvent], *, raise_error: bool = True
+    ) -> Optional[TEvent]:
+        event = self.events.get(event_type)  # type: ignore
+        if event is None and raise_error:
+            raise KeyError(f"Event {event_type} not found in response")
+        elif not isinstance(event, event_type):
+            raise TypeError(f"Event {event_type} is not of type {event_type}")
+        return event

--- a/src/hexagonal/entrypoints/app.py
+++ b/src/hexagonal/entrypoints/app.py
@@ -1,6 +1,6 @@
 # pyright: reportMissingParameterType=none, reportGeneralTypeIssues=none
 
-from typing import Type
+from typing import Mapping, Optional, Type
 
 from hexagonal.adapters.drivers import ApplicationProxyAdapter
 from hexagonal.application import Application
@@ -19,23 +19,27 @@ class AppEntrypoint(Entrypoint[IBaseApplication[TManager]]):
     BUS_GROUP: Type[BusEntrypointGroup[TManager]] = BusEntrypointGroup[TManager]
 
     @classmethod
-    def setBusApp(cls, bus_app: Type[Entrypoint[IBusApp[TManager]]]):
+    def setBusApp(cls, bus_app: Type[Entrypoint[IBusApp[TManager]]]) -> None:
         cls.BUS_APP = bus_app
 
     @classmethod
-    def setOutbox(cls, outbox: Type[Entrypoint[IPairInboxOutbox[TManager]]]):
+    def setOutbox(cls, outbox: Type[Entrypoint[IPairInboxOutbox[TManager]]]) -> None:
         cls.OUTBOX = outbox
 
     @classmethod
-    def setBusInfrastructure(cls, bus_infrastructure: Type[BusEntrypoint[TManager]]):
+    def setBusInfrastructure(
+        cls, bus_infrastructure: Type[BusEntrypoint[TManager]]
+    ) -> None:
         cls.BUS_INFRASTRUCTURE = bus_infrastructure
 
     @classmethod
-    def setBusEntrypointGroup(cls, bus_group: Type[BusEntrypointGroup[TManager]]):
+    def setBusEntrypointGroup(
+        cls, bus_group: Type[BusEntrypointGroup[TManager]]
+    ) -> None:
         cls.BUS_GROUP = bus_group
 
     @classmethod
-    def get(cls, env=None) -> IBaseApplication[TManager]:
+    def get(cls, env: Optional[Mapping[str, str]] = None) -> IBaseApplication[TManager]:
         env = cls.construct_env(env)
         if not hasattr(cls, "BUS_APP"):
             raise ValueError("Bus app is not configured")
@@ -51,3 +55,6 @@ class AppEntrypoint(Entrypoint[IBaseApplication[TManager]]):
         bus_infrastructure = GeneralBusEntrypoint.get(env)
         app = Application(bus_app, bus_infrastructure)
         return ApplicationProxyAdapter(app)
+
+
+__all__ = ["AppEntrypoint"]

--- a/src/hexagonal/entrypoints/base.py
+++ b/src/hexagonal/entrypoints/base.py
@@ -23,7 +23,7 @@ class Entrypoint(ABC, Generic[T]):
     name: ClassVar[str]
 
     @classmethod
-    def setName(cls, name: str | None = None):
+    def setName(cls, name: str | None = None) -> None:
         if hasattr(cls, "name"):
             return
         cls.name = name or cls.__name__
@@ -68,7 +68,7 @@ class EntrypointGroup(Entrypoint[T]):
         cls.entrypoints = entrypoints
 
     @classmethod
-    def addEntrypoint(cls, entrypoint: Type[Entrypoint[T]]):
+    def addEntrypoint(cls, entrypoint: Type[Entrypoint[T]]) -> None:
         cls.entrypoints.append(entrypoint)
 
     @classmethod

--- a/src/hexagonal/entrypoints/bus.py
+++ b/src/hexagonal/entrypoints/bus.py
@@ -21,7 +21,7 @@ class BusEntrypoint(Entrypoint[IBusInfrastructure[TManager]], ABC):
     OUTBOX: Type[Entrypoint[IPairInboxOutbox[TManager]]]
 
     @classmethod
-    def setOutbox(cls, outbox: Type[Entrypoint[IPairInboxOutbox[TManager]]]):
+    def setOutbox(cls, outbox: Type[Entrypoint[IPairInboxOutbox[TManager]]]) -> None:
         cls.OUTBOX = outbox
 
 
@@ -29,7 +29,9 @@ class InMemoryBusEntrypoint(BusEntrypoint[TManager]):
     name = "inmemory"
 
     @classmethod
-    def get(cls, env: Optional[Mapping[str, str]] = None):
+    def get(
+        cls, env: Optional[Mapping[str, str]] = None
+    ) -> IBusInfrastructure[TManager]:
         env = cls.construct_env(env)
         outbox = cls.OUTBOX.get(env)
         logger.info("Using %s for events", type(outbox).__name__)
@@ -42,7 +44,9 @@ class InMemoryQueueBusEntrypoint(BusEntrypoint[TManager]):
     name = "inmemory_queue"
 
     @classmethod
-    def get(cls, env: Optional[Mapping[str, str]] = None):
+    def get(
+        cls, env: Optional[Mapping[str, str]] = None
+    ) -> IBusInfrastructure[TManager]:
         env = cls.construct_env(env)
         outbox = cls.OUTBOX.get(env)
         logger.info("Using %s for events", type(outbox).__name__)
@@ -66,3 +70,11 @@ class BusEntrypointGroup(EntrypointGroup[IBusInfrastructure[TManager]]):
         entry = super().getEntrypoint(env)
 
         return cast(Type[BusEntrypoint[TManager]], entry)
+
+
+__all__ = [
+    "BusEntrypoint",
+    "BusEntrypointGroup",
+    "InMemoryBusEntrypoint",
+    "InMemoryQueueBusEntrypoint",
+]

--- a/src/hexagonal/entrypoints/sqlalchemy.py
+++ b/src/hexagonal/entrypoints/sqlalchemy.py
@@ -23,8 +23,8 @@ from hexagonal.adapters.drivens.repository.sqlalchemy.env_vars import (
 )
 from hexagonal.entrypoints import AppEntrypoint, Entrypoint
 
-# Cache for infrastructure instances to ensure same database URL reuses the same
-# datastore and connection manager. Key is the database URL.
+# Cache for infrastructure instances to ensure the same database URL reuses the
+# same immutable datastore and mapper bundle. Key is the database URL.
 _infrastructure_cache: dict[str, SQLAlchemyInfrastructure] = {}
 
 
@@ -33,6 +33,11 @@ def clear_infrastructure_cache() -> None:
 
     Useful for testing when you need to reset the cached infrastructure.
     """
+    for infrastructure in _infrastructure_cache.values():
+        try:
+            infrastructure.datastore.dispose()
+        except Exception:
+            pass
     _infrastructure_cache.clear()
 
 

--- a/src/hexagonal/entrypoints/sqlite.py
+++ b/src/hexagonal/entrypoints/sqlite.py
@@ -15,7 +15,7 @@ from hexagonal.entrypoints import AppEntrypoint, Entrypoint
 
 class SQLiteInfrastructureEntrypoint(Entrypoint[SQLiteInfrastructure]):
     @classmethod
-    def get(cls, env: Optional[Mapping[str, str]] = None):
+    def get(cls, env: Optional[Mapping[str, str]] = None) -> SQLiteInfrastructure:
         env = cls.construct_env(env)
         db_path = env.get("SQLITE_DB_PATH")
         if db_path is None:
@@ -35,7 +35,7 @@ class SQLiteInfrastructureEntrypoint(Entrypoint[SQLiteInfrastructure]):
 
 class SQLiteOutboxEntrypoint(Entrypoint[SQLitePairInboxOutbox]):
     @classmethod
-    def get(cls, env: Optional[Mapping[str, str]] = None):
+    def get(cls, env: Optional[Mapping[str, str]] = None) -> SQLitePairInboxOutbox:
         env = cls.construct_env(env)
         infrastructure = SQLiteInfrastructureEntrypoint.get(env)
         pair = SQLitePairInboxOutbox(
@@ -47,3 +47,10 @@ class SQLiteOutboxEntrypoint(Entrypoint[SQLitePairInboxOutbox]):
 
 class SQLiteAppEntrypoint(AppEntrypoint[SQLiteConnectionContextManager]):
     OUTBOX = SQLiteOutboxEntrypoint
+
+
+__all__ = [
+    "SQLiteAppEntrypoint",
+    "SQLiteInfrastructureEntrypoint",
+    "SQLiteOutboxEntrypoint",
+]

--- a/src/hexagonal/ports/drivens/__init__.py
+++ b/src/hexagonal/ports/drivens/__init__.py
@@ -8,6 +8,7 @@ from .buses import (
 )
 from .infrastructure import IBaseInfrastructure
 from .repository import (
+    ExecutionScope,
     IAggregateRepository,
     IBaseRepository,
     IConnectionManager,
@@ -15,11 +16,18 @@ from .repository import (
     IInboxRepository,
     IOutboxRepository,
     IPairInboxOutbox,
+    IReadScopeFactory,
+    IReadScopeRunner,
     ISearchRepository,
     IUnitOfWork,
+    IWriteScopeFactory,
+    IWriteScopeRunner,
     TAggregate,
     TManager,
+    TReadScope,
     TRepository,
+    TResult,
+    TWriteScope,
 )
 
 __all__ = [
@@ -29,6 +37,7 @@ __all__ = [
     "IEventBus",
     "IQueryBus",
     "IBusInfrastructure",
+    "ExecutionScope",
     "IInboxRepository",
     "IOutboxRepository",
     "IAggregateRepository",
@@ -36,6 +45,10 @@ __all__ = [
     "ISearchRepository",
     "IConnectionManager",
     "IUnitOfWork",
+    "IWriteScopeFactory",
+    "IReadScopeFactory",
+    "IWriteScopeRunner",
+    "IReadScopeRunner",
     "IMessageHandler",
     "IQueryHandler",
     "TManager",
@@ -44,4 +57,7 @@ __all__ = [
     "IPairInboxOutbox",
     "IEntityRepository",
     "TRepository",
+    "TResult",
+    "TWriteScope",
+    "TReadScope",
 ]

--- a/src/hexagonal/ports/drivens/__init__.py
+++ b/src/hexagonal/ports/drivens/__init__.py
@@ -16,16 +16,18 @@ from .repository import (
     IInboxRepository,
     IOutboxRepository,
     IPairInboxOutbox,
-    IReadScopeFactory,
-    IReadScopeRunner,
     ISearchRepository,
     IUnitOfWork,
-    IWriteScopeFactory,
-    IWriteScopeRunner,
     TAggregate,
     TManager,
-    TReadScope,
     TRepository,
+)
+from .scoped import (
+    IReadScopeFactory,
+    IReadScopeRunner,
+    IWriteScopeFactory,
+    IWriteScopeRunner,
+    TReadScope,
     TResult,
     TWriteScope,
 )

--- a/src/hexagonal/ports/drivens/buses.py
+++ b/src/hexagonal/ports/drivens/buses.py
@@ -14,6 +14,7 @@ from hexagonal.domain import (
     TQuery,
     TView,
 )
+from hexagonal.ports.drivens.scoped import IWriteScopeRunner, TWriteScope
 
 from .application import IMessageHandler, IQueryHandler
 from .infrastructure import IBaseInfrastructure
@@ -43,8 +44,8 @@ class IBaseMessageBus(IBaseInfrastructure, ABC, Generic[TManager]):
     def configure_scope_runtime(
         self,
         *,
-        write_scope_runner: Any | None = None,
-        outbox_repository_getter: Callable[[Any], IOutboxRepository[TManager]]
+        write_scope_runner: IWriteScopeRunner[TWriteScope] | None = None,
+        outbox_repository_getter: Callable[..., IOutboxRepository[TManager]]
         | None = None,
     ) -> None:
         """Configurar acceso a repositorios scope-aware para outbox."""
@@ -74,7 +75,7 @@ class ICommandBus(IBaseMessageBus[TManager], ABC):
     @abstractmethod
     def dispatch(
         self,
-        command: TCommand | CloudMessage[TCommand],
+        command: CloudMessage[TCommand],
         *,
         to_outbox: bool = False,
     ) -> None:

--- a/src/hexagonal/ports/drivens/buses.py
+++ b/src/hexagonal/ports/drivens/buses.py
@@ -1,7 +1,7 @@
 import threading
 from abc import ABC, abstractmethod
 from asyncio import Event
-from typing import Callable, Generic, Literal, Type, overload
+from typing import Any, Callable, Generic, Literal, Type, overload
 
 from hexagonal.domain import (
     CloudMessage,
@@ -32,6 +32,22 @@ class IBaseMessageBus(IBaseInfrastructure, ABC, Generic[TManager]):
     @abstractmethod
     def publish_from_outbox(self, limit: int | None = None):
         """Publicar mensajes desde la outbox., hasta el límite especificado."""
+        ...
+
+    @abstractmethod
+    def save_to_outbox(self, *messages: CloudMessage[Any]) -> None:
+        """Guardar mensajes en la outbox usando el scope activo si existe."""
+        ...
+
+    @abstractmethod
+    def configure_scope_runtime(
+        self,
+        *,
+        write_scope_runner: Any | None = None,
+        outbox_repository_getter: Callable[[Any], IOutboxRepository[TManager]]
+        | None = None,
+    ) -> None:
+        """Configurar acceso a repositorios scope-aware para outbox."""
         ...
 
     @abstractmethod
@@ -109,6 +125,11 @@ class IEventBus(IBaseMessageBus[TManager], ABC):
 
 
 class IQueryBus(IBaseInfrastructure, Generic[TManager]):
+    @abstractmethod
+    def configure_read_scope_runtime(
+        self, read_scope_runner: Any | None = None
+    ) -> None: ...
+
     @abstractmethod
     def register_handler(
         self,

--- a/src/hexagonal/ports/drivens/buses.py
+++ b/src/hexagonal/ports/drivens/buses.py
@@ -30,7 +30,7 @@ class IBaseMessageBus(IBaseInfrastructure, ABC, Generic[TManager]):
     def outbox_repository(self) -> IOutboxRepository[TManager]: ...
 
     @abstractmethod
-    def publish_from_outbox(self, limit: int | None = None):
+    def publish_from_outbox(self, limit: int | None = None) -> None:
         """Publicar mensajes desde la outbox., hasta el límite especificado."""
         ...
 
@@ -51,11 +51,11 @@ class IBaseMessageBus(IBaseInfrastructure, ABC, Generic[TManager]):
         ...
 
     @abstractmethod
-    def consume(self, limit: int | None = None):
+    def consume(self, limit: int | None = None) -> None:
         """Consumir mensajes desde la inbox, hasta el límite especificado."""
         ...
 
-    async def consume_async(self, shutdown_event: Event | threading.Event): ...
+    async def consume_async(self, shutdown_event: Event | threading.Event) -> None: ...
 
 
 class ICommandBus(IBaseMessageBus[TManager], ABC):
@@ -89,7 +89,9 @@ class ICommandBus(IBaseMessageBus[TManager], ABC):
 
 class IEventBus(IBaseMessageBus[TManager], ABC):
     @abstractmethod
-    def subscribe(self, event_type: Type[TEvent], handler: IMessageHandler[TEvent]):
+    def subscribe(
+        self, event_type: Type[TEvent], handler: IMessageHandler[TEvent]
+    ) -> None:
         """Suscribir un manejador a un tipo de evento."""
         ...
 
@@ -98,7 +100,7 @@ class IEventBus(IBaseMessageBus[TManager], ABC):
         self,
         event_type: Type[TEvent],
         *handlers: IMessageHandler[TEvent],
-    ): ...
+    ) -> None: ...
 
     @abstractmethod
     def publish(self, *events: CloudMessage[TEvent]) -> None:
@@ -135,10 +137,10 @@ class IQueryBus(IBaseInfrastructure, Generic[TManager]):
         self,
         query_type: Type[TQuery],
         handler: IQueryHandler[TManager, TQuery, TView],
-    ): ...
+    ) -> None: ...
 
     @abstractmethod
-    def unregister_handler(self, query_type: Type[Query[TView]]): ...
+    def unregister_handler(self, query_type: Type[Query[TView]]) -> None: ...
 
     @overload
     def get(

--- a/src/hexagonal/ports/drivens/infrastructure.py
+++ b/src/hexagonal/ports/drivens/infrastructure.py
@@ -12,7 +12,7 @@ class IBaseInfrastructure(ABC):
     @abstractmethod
     def initialize(self, env: Mapping[str, str]) -> None: ...
 
-    def verify(self):
+    def verify(self) -> None:
         if not self.initialized:
             raise InfrastructureNotInitialized(
                 f"{self.__class__.__name__} is not initialized"

--- a/src/hexagonal/ports/drivens/repository.py
+++ b/src/hexagonal/ports/drivens/repository.py
@@ -1,17 +1,10 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Mapping, Protocol, Self, Sequence, TypeVar
+from typing import Any, Generic, Mapping, Self, Sequence, TypeVar
 from uuid import UUID
 
-from hexagonal.domain import (
-    CloudMessage,
-    TAggregate,
-    TEntity,
-    TIdEntity,
-    TQuery,
-    TView,
-)
+from hexagonal.domain import CloudMessage, TAggregate, TEntity, TIdEntity, TQuery, TView
 
 from .infrastructure import IBaseInfrastructure
 
@@ -23,31 +16,6 @@ class IConnectionManager(IBaseInfrastructure, ABC):
 
 
 TManager = TypeVar("TManager", bound=IConnectionManager)
-TResult = TypeVar("TResult")
-TReadScope = TypeVar("TReadScope")
-TWriteScope = TypeVar("TWriteScope")
-TReadScope_co = TypeVar("TReadScope_co", covariant=True)
-TWriteScope_co = TypeVar("TWriteScope_co", covariant=True)
-
-
-class IWriteScopeFactory(Protocol, Generic[TWriteScope_co]):
-    def create_write_scope(self) -> TWriteScope_co: ...
-
-
-class IReadScopeFactory(Protocol, Generic[TReadScope_co]):
-    def create_read_scope(self) -> TReadScope_co: ...
-
-
-class IWriteScopeRunner(Protocol, Generic[TWriteScope_co]):
-    def run_in_write_scope(
-        self, work: Callable[[TWriteScope_co], TResult]
-    ) -> TResult: ...
-
-
-class IReadScopeRunner(Protocol, Generic[TReadScope_co]):
-    def run_in_read_scope(
-        self, work: Callable[[TReadScope_co], TResult]
-    ) -> TResult: ...
 
 
 class IBaseRepository(IBaseInfrastructure, Generic[TManager]):
@@ -210,30 +178,3 @@ class IPairInboxOutbox(IBaseInfrastructure, Generic[TManager]):
 
 
 TRepository = TypeVar("TRepository", bound=IBaseRepository[Any])
-
-__all__ = [
-    "ExecutionScope",
-    "IAggregateRepository",
-    "IBaseRepository",
-    "IConnectionManager",
-    "IEntityRepository",
-    "IInboxRepository",
-    "IOutboxRepository",
-    "IPairInboxOutbox",
-    "IReadScopeFactory",
-    "IReadScopeRunner",
-    "ISearchRepository",
-    "IUnitOfWork",
-    "IWriteScopeFactory",
-    "IWriteScopeRunner",
-    "TAggregate",
-    "TEntity",
-    "TIdEntity",
-    "TManager",
-    "TQuery",
-    "TReadScope",
-    "TRepository",
-    "TResult",
-    "TView",
-    "TWriteScope",
-]

--- a/src/hexagonal/ports/drivens/repository.py
+++ b/src/hexagonal/ports/drivens/repository.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Generic, Self, Sequence, TypeVar
+from dataclasses import dataclass
+from typing import Any, Callable, Generic, Mapping, Protocol, Self, Sequence, TypeVar
 from uuid import UUID
 
 from hexagonal.domain import (
@@ -22,6 +23,31 @@ class IConnectionManager(IBaseInfrastructure, ABC):
 
 
 TManager = TypeVar("TManager", bound=IConnectionManager)
+TResult = TypeVar("TResult")
+TReadScope = TypeVar("TReadScope")
+TWriteScope = TypeVar("TWriteScope")
+
+
+@dataclass(frozen=True)
+class ExecutionScope(Generic[TManager]):
+    uow: "IUnitOfWork[TManager]"
+    repositories: Mapping[str, object]
+
+
+class IWriteScopeFactory(Protocol, Generic[TWriteScope]):
+    def create_write_scope(self) -> TWriteScope: ...
+
+
+class IReadScopeFactory(Protocol, Generic[TReadScope]):
+    def create_read_scope(self) -> TReadScope: ...
+
+
+class IWriteScopeRunner(Protocol, Generic[TWriteScope]):
+    def run_in_write_scope(self, work: Callable[[TWriteScope], TResult]) -> TResult: ...
+
+
+class IReadScopeRunner(Protocol, Generic[TReadScope]):
+    def run_in_read_scope(self, work: Callable[[TReadScope], TResult]) -> TResult: ...
 
 
 class IBaseRepository(IBaseInfrastructure, Generic[TManager]):
@@ -30,9 +56,13 @@ class IBaseRepository(IBaseInfrastructure, Generic[TManager]):
     def connection_manager(self) -> TManager: ...
 
     @abstractmethod
+    # Compatibility shim for legacy singleton-UoW wiring. New scope-based flows
+    # construct repositories with the correct manager and should not rely on this.
     def attach_to_unit_of_work(self, uow: "IUnitOfWork[TManager]") -> None: ...
 
     @abstractmethod
+    # Compatibility shim paired with attach_to_unit_of_work(); remove once Phase 5
+    # eliminates legacy mutable attachment paths.
     def detach_from_unit_of_work(self) -> None: ...
 
 
@@ -48,9 +78,11 @@ class IUnitOfWork(IBaseInfrastructure, ABC, Generic[TManager]):
     def rollback(self) -> None: ...
 
     @abstractmethod
+    # Compatibility shim for legacy registration paths only.
     def attach_repo(self, repo: IBaseRepository[TManager]) -> None: ...
 
     @abstractmethod
+    # Compatibility shim for legacy registration paths only.
     def detach_repo(self, repo: IBaseRepository[TManager]) -> None: ...
 
     def __enter__(self) -> Self:

--- a/src/hexagonal/ports/drivens/repository.py
+++ b/src/hexagonal/ports/drivens/repository.py
@@ -178,3 +178,20 @@ class IPairInboxOutbox(IBaseInfrastructure, Generic[TManager]):
 
 
 TRepository = TypeVar("TRepository", bound=IBaseRepository[Any])
+
+
+__all__ = [
+    "ExecutionScope",
+    "IConnectionManager",
+    "IAggregateRepository",
+    "IBaseRepository",
+    "IEntityRepository",
+    "IInboxRepository",
+    "IOutboxRepository",
+    "IPairInboxOutbox",
+    "ISearchRepository",
+    "IUnitOfWork",
+    "TAggregate",
+    "TManager",
+    "TRepository",
+]

--- a/src/hexagonal/ports/drivens/repository.py
+++ b/src/hexagonal/ports/drivens/repository.py
@@ -30,12 +30,6 @@ TReadScope_co = TypeVar("TReadScope_co", covariant=True)
 TWriteScope_co = TypeVar("TWriteScope_co", covariant=True)
 
 
-@dataclass(frozen=True)
-class ExecutionScope(Generic[TManager]):
-    uow: "IUnitOfWork[TManager]"
-    repositories: Mapping[str, object]
-
-
 class IWriteScopeFactory(Protocol, Generic[TWriteScope_co]):
     def create_write_scope(self) -> TWriteScope_co: ...
 
@@ -70,6 +64,12 @@ class IBaseRepository(IBaseInfrastructure, Generic[TManager]):
     # Compatibility shim paired with attach_to_unit_of_work(); remove once Phase 5
     # eliminates legacy mutable attachment paths.
     def detach_from_unit_of_work(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class ExecutionScope(Generic[TManager]):
+    uow: "IUnitOfWork[TManager]"
+    repositories: Mapping[str, IBaseRepository[TManager]]
 
 
 class IUnitOfWork(IBaseInfrastructure, ABC, Generic[TManager]):

--- a/src/hexagonal/ports/drivens/repository.py
+++ b/src/hexagonal/ports/drivens/repository.py
@@ -26,6 +26,8 @@ TManager = TypeVar("TManager", bound=IConnectionManager)
 TResult = TypeVar("TResult")
 TReadScope = TypeVar("TReadScope")
 TWriteScope = TypeVar("TWriteScope")
+TReadScope_co = TypeVar("TReadScope_co", covariant=True)
+TWriteScope_co = TypeVar("TWriteScope_co", covariant=True)
 
 
 @dataclass(frozen=True)
@@ -34,20 +36,24 @@ class ExecutionScope(Generic[TManager]):
     repositories: Mapping[str, object]
 
 
-class IWriteScopeFactory(Protocol, Generic[TWriteScope]):
-    def create_write_scope(self) -> TWriteScope: ...
+class IWriteScopeFactory(Protocol, Generic[TWriteScope_co]):
+    def create_write_scope(self) -> TWriteScope_co: ...
 
 
-class IReadScopeFactory(Protocol, Generic[TReadScope]):
-    def create_read_scope(self) -> TReadScope: ...
+class IReadScopeFactory(Protocol, Generic[TReadScope_co]):
+    def create_read_scope(self) -> TReadScope_co: ...
 
 
-class IWriteScopeRunner(Protocol, Generic[TWriteScope]):
-    def run_in_write_scope(self, work: Callable[[TWriteScope], TResult]) -> TResult: ...
+class IWriteScopeRunner(Protocol, Generic[TWriteScope_co]):
+    def run_in_write_scope(
+        self, work: Callable[[TWriteScope_co], TResult]
+    ) -> TResult: ...
 
 
-class IReadScopeRunner(Protocol, Generic[TReadScope]):
-    def run_in_read_scope(self, work: Callable[[TReadScope], TResult]) -> TResult: ...
+class IReadScopeRunner(Protocol, Generic[TReadScope_co]):
+    def run_in_read_scope(
+        self, work: Callable[[TReadScope_co], TResult]
+    ) -> TResult: ...
 
 
 class IBaseRepository(IBaseInfrastructure, Generic[TManager]):
@@ -204,3 +210,30 @@ class IPairInboxOutbox(IBaseInfrastructure, Generic[TManager]):
 
 
 TRepository = TypeVar("TRepository", bound=IBaseRepository[Any])
+
+__all__ = [
+    "ExecutionScope",
+    "IAggregateRepository",
+    "IBaseRepository",
+    "IConnectionManager",
+    "IEntityRepository",
+    "IInboxRepository",
+    "IOutboxRepository",
+    "IPairInboxOutbox",
+    "IReadScopeFactory",
+    "IReadScopeRunner",
+    "ISearchRepository",
+    "IUnitOfWork",
+    "IWriteScopeFactory",
+    "IWriteScopeRunner",
+    "TAggregate",
+    "TEntity",
+    "TIdEntity",
+    "TManager",
+    "TQuery",
+    "TReadScope",
+    "TRepository",
+    "TResult",
+    "TView",
+    "TWriteScope",
+]

--- a/src/hexagonal/ports/drivens/scoped.py
+++ b/src/hexagonal/ports/drivens/scoped.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Callable, Generic, Protocol, TypeVar, Union
+
+logger = logging.getLogger(__name__)
+
+TWriteScope = TypeVar("TWriteScope")
+TReadScope = TypeVar("TReadScope")
+TWriteScope_contra = TypeVar("TWriteScope_contra", contravariant=True)
+TResult = TypeVar("TResult")
+TReadScope_co = TypeVar("TReadScope_co", covariant=True)
+TWriteScope_co = TypeVar("TWriteScope_co", covariant=True)
+
+TScope = Union[TWriteScope, TReadScope]
+
+
+class IWriteScopeFactory(Protocol, Generic[TWriteScope_co]):
+    def create_write_scope(self) -> TWriteScope_co: ...
+
+
+class IReadScopeFactory(Protocol, Generic[TReadScope_co]):
+    def create_read_scope(self) -> TReadScope_co: ...
+
+
+class IWriteScopeRunner(Protocol, Generic[TWriteScope_co]):
+    def run_in_write_scope(
+        self, work: Callable[[TWriteScope_co], TResult]
+    ) -> TResult: ...
+
+
+class IReadScopeRunner(Protocol, Generic[TReadScope_co]):
+    def run_in_read_scope(
+        self, work: Callable[[TReadScope_co], TResult]
+    ) -> TResult: ...

--- a/src/hexagonal/ports/drivens/scoped.py
+++ b/src/hexagonal/ports/drivens/scoped.py
@@ -22,6 +22,9 @@ class IReadScopeFactory(Protocol, Generic[TReadScope_co]):
 
 
 class IWriteScopeRunner(Protocol, Generic[TWriteScope_co]):
+    @property
+    def current_write_scope(self) -> TWriteScope_co | None: ...
+
     def run_in_write_scope(
         self, work: Callable[[TWriteScope_co], TResult]
     ) -> TResult: ...

--- a/src/hexagonal/ports/drivers/app.py
+++ b/src/hexagonal/ports/drivers/app.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Generic
 
-from hexagonal.domain import CloudMessage, TCommand, TEvent
+from hexagonal.domain import CloudMessage, CommandOutcome, TCommand, TEvento
 from hexagonal.ports.drivens import (
     IBusInfrastructure,
     ICommandBus,
@@ -54,5 +54,5 @@ class IBaseApplication(ABC, Generic[TManager]):
     def dispatch_and_wait_events(
         self,
         command: CloudMessage[TCommand],
-        *event_types: type[TEvent],
-    ) -> dict[type[TEvent], TEvent | None]: ...
+        *event_types: type[TEvento],
+    ) -> CommandOutcome[TCommand]: ...

--- a/src/tests/docs/test_docs_consistency.py
+++ b/src/tests/docs/test_docs_consistency.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+import re
 from collections import Counter
 from pathlib import Path
-import re
-
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DOCS_EVIDENCE_MAP = REPO_ROOT / "docs/reference/evidence-map.yaml"

--- a/src/tests/docs/test_docs_consistency.py
+++ b/src/tests/docs/test_docs_consistency.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from collections import Counter
 from pathlib import Path
+from typing import TypedDict
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DOCS_EVIDENCE_MAP = REPO_ROOT / "docs/reference/evidence-map.yaml"
@@ -12,11 +13,19 @@ SKILL_EVIDENCE_MAP = (
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.*\S)\s*$", re.MULTILINE)
 
 
+class EvidenceMap(TypedDict):
+    page_paths: list[str]
+    evidence_paths: list[str]
+    claim_anchors: list[tuple[str, str]]
+    page_ids: list[str]
+    claim_ids: list[str]
+
+
 def _value(raw: str) -> str:
     return raw.split(":", 1)[1].strip()
 
 
-def _parse_evidence_map(path: Path) -> dict[str, list[str] | list[tuple[str, str]]]:
+def _parse_evidence_map(path: Path) -> EvidenceMap:
     page_paths: list[str] = []
     evidence_paths: list[str] = []
     claim_anchors: list[tuple[str, str]] = []
@@ -82,7 +91,7 @@ def test_evidence_maps_stay_in_sync() -> None:
 
 def test_evidence_map_paths_exist_and_ids_are_unique() -> None:
     parsed = _parse_evidence_map(DOCS_EVIDENCE_MAP)
-    all_paths = [*parsed["page_paths"], *parsed["evidence_paths"]]
+    all_paths: list[str] = parsed["page_paths"] + parsed["evidence_paths"]
 
     missing_paths = [
         relative for relative in all_paths if not (REPO_ROOT / relative).exists()

--- a/src/tests/docs/test_sqlalchemy_public_surface.py
+++ b/src/tests/docs/test_sqlalchemy_public_surface.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PUBLIC_SURFACE = REPO_ROOT / "src/hexagonal/integrations/sqlalchemy.py"
 

--- a/src/tests/test_example_api_compatibility.py
+++ b/src/tests/test_example_api_compatibility.py
@@ -1,4 +1,4 @@
-from example import exampleAPI, exampleEntrypoint
+from example import exampleEntrypoint
 from example.app.entrypoints.db.sqlalchemy import SQLAlchemyexampleEntrypoint
 from example.app.entrypoints.main import exampleEntrypoint as main_example_entrypoint
 from example.contacto.domain.shared import TipoContacto

--- a/src/tests/test_example_api_compatibility.py
+++ b/src/tests/test_example_api_compatibility.py
@@ -1,0 +1,52 @@
+from example import exampleAPI, exampleEntrypoint
+from example.app.entrypoints.db.sqlalchemy import SQLAlchemyexampleEntrypoint
+from example.app.entrypoints.main import exampleEntrypoint as main_example_entrypoint
+from example.contacto.domain.shared import TipoContacto
+from tests.use_cases.base import (
+    bootstrap_example_stack,
+    build_example_env,
+    count_outbox_rows,
+    migrate_example_database,
+    reset_example_runtime_state,
+)
+
+
+def test_public_example_exports_keep_bootstrap_contract(tmp_path):
+    assert exampleEntrypoint is main_example_entrypoint
+
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "example-api-compatibility.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    assert api.app is app
+    assert api.contacto.app is app
+
+    contacto_api = api.contacto.contacto
+    response = contacto_api.crear(TipoContacto.EMAIL.value, "compat@example.com")
+    created = response.get(contacto_api.Events.CREADO.value, raise_error=False)
+
+    assert created is not None
+    assert (
+        contacto_api.get(created.id_contacto.value).contacto.value
+        == "compat@example.com"
+    )
+    assert count_outbox_rows(app) == 2
+    assert count_outbox_rows(app, published=True) == 2
+    assert count_outbox_rows(app, published=False) == 0
+
+
+def test_sqlalchemy_example_entrypoint_still_builds_a_bus_app(tmp_path):
+    env = build_example_env(
+        tmp_path / "example-db-entrypoint-compatibility.db",
+        {"ENV_BUS": "inmemory"},
+    )
+    reset_example_runtime_state()
+    migrate_example_database(env)
+
+    app = SQLAlchemyexampleEntrypoint.get(env)
+
+    assert app.infrastructure is not None
+    assert app.uow is app.infrastructure.uow
+
+    reset_example_runtime_state()

--- a/src/tests/test_parallel_dispatch_isolation.py
+++ b/src/tests/test_parallel_dispatch_isolation.py
@@ -1,0 +1,141 @@
+import threading
+from pathlib import Path
+
+from example.contacto.domain.shared import TipoContacto
+from tests.use_cases.base import bootstrap_example_stack
+
+
+def test_write_scope_runner_isolates_worker_threads(tmp_path: Path):
+    _, app, _ = bootstrap_example_stack(
+        tmp_path / "parallel-dispatch-isolation.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    runner = app.bus_app.infrastructure.write_scope_runner
+    seen: dict[str, tuple[int, int, int]] = {}
+
+    seen["main"] = runner.run_in_write_scope(
+        lambda scope: (
+            threading.get_ident(),
+            id(scope.uow),
+            id(scope.uow.connection_manager),
+        )
+    )
+
+    worker_done = threading.Event()
+
+    def worker() -> None:
+        seen["worker"] = runner.run_in_write_scope(
+            lambda scope: (
+                threading.get_ident(),
+                id(scope.uow),
+                id(scope.uow.connection_manager),
+            )
+        )
+        worker_done.set()
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert worker_done.is_set()
+    assert seen["worker"][0] != seen["main"][0]
+    assert seen["worker"][1] != seen["main"][1]
+    assert seen["worker"][2] != seen["main"][2]
+
+
+def test_write_scope_runner_reuses_same_scope_for_nested_same_thread_work(tmp_path):
+    _, app, _ = bootstrap_example_stack(
+        tmp_path / "parallel-dispatch-nested.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    runner = app.bus_app.infrastructure.write_scope_runner
+
+    def outer(scope):
+        current_scope_ids = (id(scope.uow), id(scope.uow.connection_manager))
+        nested_scope_ids = runner.run_in_write_scope(
+            lambda nested_scope: (
+                id(nested_scope.uow),
+                id(nested_scope.uow.connection_manager),
+            )
+        )
+        return current_scope_ids, nested_scope_ids
+
+    current_scope_ids, nested_scope_ids = runner.run_in_write_scope(outer)
+
+    assert nested_scope_ids == current_scope_ids
+
+
+def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path: Path):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-dispatch-command-worker.db",
+        {
+            "ENV_BUS": "inmemory_queue",
+            "EVENT_BUS_WORKER_DAEMON": "false",
+        },
+    )
+
+    runner = app.bus_app.infrastructure.write_scope_runner
+    main_scope = runner.run_in_write_scope(
+        lambda scope: (
+            threading.get_ident(),
+            id(scope.uow),
+            id(scope.uow.connection_manager),
+        )
+    )
+
+    created_scopes: list[tuple[int, int, int]] = []
+    original_create_write_scope = runner._create_write_scope
+
+    def record_write_scope():
+        scope = original_create_write_scope()
+        created_scopes.append(
+            (
+                threading.get_ident(),
+                id(scope.uow),
+                id(scope.uow.connection_manager),
+            )
+        )
+        return scope
+
+    runner._create_write_scope = record_write_scope
+    created_event = {}
+    contacto_api = api.contacto.contacto
+
+    app.command_bus.consume()
+    app.event_bus.consume()
+    app.event_bus.wait_for_publish(
+        contacto_api.Events.CREADO.value,
+        lambda event: created_event.setdefault("value", event),
+    )
+
+    try:
+        response = contacto_api.crear(
+            TipoContacto.EMAIL.value,
+            "queued-worker@example.com",
+            async_dispatch=True,
+        )
+
+        assert response.has_events is False
+
+        app.command_bus.publish_from_outbox()
+        app.command_bus.queue.join()
+        app.event_bus.queue.join()
+
+        created = created_event.get("value")
+        assert created is not None
+        assert (
+            contacto_api.get(created.id_contacto.value).contacto.value
+            == "queued-worker@example.com"
+        )
+
+        worker_scopes = [scope for scope in created_scopes if scope[0] != main_scope[0]]
+
+        assert worker_scopes
+        assert all(scope[1] != main_scope[1] for scope in worker_scopes)
+        assert all(scope[2] != main_scope[2] for scope in worker_scopes)
+    finally:
+        runner._create_write_scope = original_create_write_scope
+        app.command_bus.shutdown()
+        app.event_bus.shutdown()

--- a/src/tests/test_parallel_safe_scopes.py
+++ b/src/tests/test_parallel_safe_scopes.py
@@ -1,5 +1,4 @@
 from example.contacto.domain.shared import TipoContacto
-
 from tests.use_cases.base import (
     bootstrap_example_stack,
     count_inbox_rows,

--- a/src/tests/test_parallel_safe_scopes.py
+++ b/src/tests/test_parallel_safe_scopes.py
@@ -1,0 +1,98 @@
+from example.contacto.domain.shared import TipoContacto
+
+from tests.use_cases.base import (
+    bootstrap_example_stack,
+    count_inbox_rows,
+    count_outbox_rows,
+)
+
+
+def test_write_scopes_create_fresh_mutable_objects_and_reuse_cached_primitives(
+    tmp_path,
+):
+    _, app, _ = bootstrap_example_stack(
+        tmp_path / "parallel-safe-scopes.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    infrastructure = app.bus_app.infrastructure
+
+    first_scope = infrastructure.create_write_scope()
+    second_scope = infrastructure.create_write_scope()
+
+    assert first_scope is not second_scope
+    assert first_scope.uow is not second_scope.uow
+    assert first_scope.uow.connection_manager is not second_scope.uow.connection_manager
+    assert first_scope.contacto_repository is not second_scope.contacto_repository
+    assert first_scope.entidad_repository is not second_scope.entidad_repository
+    assert (
+        first_scope.entidad_contacto_repository
+        is not second_scope.entidad_contacto_repository
+    )
+
+    assert (
+        first_scope.uow.connection_manager.datastore
+        is second_scope.uow.connection_manager.datastore
+    )
+    assert (
+        first_scope.contacto_repository._mapper
+        is second_scope.contacto_repository._mapper
+    )
+    assert (
+        first_scope.entidad_repository._mapper
+        is second_scope.entidad_repository._mapper
+    )
+    assert first_scope.inbox_repository is not second_scope.inbox_repository
+    assert first_scope.outbox_repository is not second_scope.outbox_repository
+
+
+def test_scoped_command_execution_publishes_without_leaking_pending_outbox_rows(
+    tmp_path,
+):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-safe-scope-outbox.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    before_outbox_total = count_outbox_rows(app)
+    before_outbox_pending = count_outbox_rows(app, published=False)
+    before_inbox_processed = count_inbox_rows(app, processed=True)
+
+    api.contacto.contacto.crear(TipoContacto.EMAIL.value, "scope-check@example.com")
+
+    assert count_outbox_rows(app) - before_outbox_total == 2
+    assert count_outbox_rows(app, published=False) == before_outbox_pending
+    assert count_outbox_rows(app, published=True) - before_outbox_total == 2
+    assert count_inbox_rows(app, processed=True) - before_inbox_processed == 1
+
+
+def test_read_scopes_create_fresh_managers_and_repositories(tmp_path):
+    _, app, _ = bootstrap_example_stack(
+        tmp_path / "parallel-safe-read-scopes.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    infrastructure = app.bus_app.infrastructure
+    runner = infrastructure.read_scope_runner
+
+    first_scope = runner.run_in_read_scope(
+        lambda manager: (
+            manager,
+            infrastructure.build_contacto_repository(manager),
+            infrastructure.build_entidad_contacto_repository(manager),
+            manager.datastore,
+        )
+    )
+    second_scope = runner.run_in_read_scope(
+        lambda manager: (
+            manager,
+            infrastructure.build_contacto_repository(manager),
+            infrastructure.build_entidad_contacto_repository(manager),
+            manager.datastore,
+        )
+    )
+
+    assert first_scope[0] is not second_scope[0]
+    assert first_scope[1] is not second_scope[1]
+    assert first_scope[2] is not second_scope[2]
+    assert first_scope[3] is second_scope[3]

--- a/src/tests/use_cases/base.py
+++ b/src/tests/use_cases/base.py
@@ -10,6 +10,7 @@ from sqlalchemy import func, select
 
 from example import exampleAPI, exampleEntrypoint
 from hexagonal.entrypoints.sqlalchemy import clear_infrastructure_cache
+from hexagonal.ports.drivers import IBaseApplication
 
 logger = getLogger(__name__)
 
@@ -18,7 +19,9 @@ def get_example_write_scope(app: Any) -> Any:
     return app.bus_app.infrastructure.create_write_scope()
 
 
-def count_outbox_rows(app: Any, *, published: bool | None = None) -> int:
+def count_outbox_rows(
+    app: IBaseApplication[Any], *, published: bool | None = None
+) -> int:
     scope = get_example_write_scope(app)
     table = scope.outbox_repository._outbox_table
     stmt = select(func.count()).select_from(table)
@@ -31,7 +34,9 @@ def count_outbox_rows(app: Any, *, published: bool | None = None) -> int:
         return int(conn.execute(stmt).scalar_one())
 
 
-def count_inbox_rows(app: Any, *, processed: bool | None = None) -> int:
+def count_inbox_rows(
+    app: IBaseApplication[Any], *, processed: bool | None = None
+) -> int:
     scope = get_example_write_scope(app)
     table = scope.inbox_repository._inbox_table
     stmt = select(func.count()).select_from(table)
@@ -78,7 +83,7 @@ def bootstrap_example_stack(
     env: Mapping[str, str] | None = None,
     *,
     register_topics: bool = True,
-) -> tuple[dict[str, str], Any, Any]:
+) -> tuple[dict[str, str], IBaseApplication[Any], exampleAPI[Any]]:
     bootstrap_env = build_example_env(temp_db, env)
     reset_example_runtime_state()
     migrate_example_database(bootstrap_env)

--- a/src/tests/use_cases/base.py
+++ b/src/tests/use_cases/base.py
@@ -1,13 +1,93 @@
 import os
 from logging import getLogger
+from pathlib import Path
+from typing import Any, Mapping
 
 from alembic import command
 from alembic.config import Config
 from eventsourcing.utils import clear_topic_cache
+from sqlalchemy import func, select
 
 from example import exampleAPI, exampleEntrypoint
+from hexagonal.entrypoints.sqlalchemy import clear_infrastructure_cache
 
 logger = getLogger(__name__)
+
+
+def get_example_write_scope(app: Any) -> Any:
+    return app.bus_app.infrastructure.create_write_scope()
+
+
+def count_outbox_rows(app: Any, *, published: bool | None = None) -> int:
+    scope = get_example_write_scope(app)
+    table = scope.outbox_repository._outbox_table
+    stmt = select(func.count()).select_from(table)
+    if published is True:
+        stmt = stmt.where(table.c.published_at.is_not(None))
+    elif published is False:
+        stmt = stmt.where(table.c.published_at.is_(None))
+
+    with scope.outbox_repository.connection_manager.cursor(commit=False) as conn:
+        return int(conn.execute(stmt).scalar_one())
+
+
+def count_inbox_rows(app: Any, *, processed: bool | None = None) -> int:
+    scope = get_example_write_scope(app)
+    table = scope.inbox_repository._inbox_table
+    stmt = select(func.count()).select_from(table)
+    if processed is True:
+        stmt = stmt.where(table.c.processed_at.is_not(None))
+    elif processed is False:
+        stmt = stmt.where(table.c.processed_at.is_(None))
+
+    with scope.inbox_repository.connection_manager.cursor(commit=False) as conn:
+        return int(conn.execute(stmt).scalar_one())
+
+
+def reset_example_runtime_state() -> None:
+    clear_topic_cache()
+    clear_infrastructure_cache()
+
+
+def build_example_env(
+    temp_db: str | Path,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    bootstrap_env = dict(env or {})
+    bootstrap_env.update(
+        {
+            "SQLALCHEMY_DATABASE_URL": f"sqlite:///{temp_db}",
+            "SCHEMA_NAME": "",
+        }
+    )
+    return bootstrap_env
+
+
+def migrate_example_database(env: Mapping[str, str]) -> None:
+    for key, value in env.items():
+        os.environ[key] = value
+    os.environ.pop("SCHEMA_NAME", None)
+
+    alembic_cfg = Config("alembic.ini")
+    command.downgrade(alembic_cfg, "base")
+    command.upgrade(alembic_cfg, "head")
+
+
+def bootstrap_example_stack(
+    temp_db: str | Path,
+    env: Mapping[str, str] | None = None,
+    *,
+    register_topics: bool = True,
+) -> tuple[dict[str, str], Any, Any]:
+    bootstrap_env = build_example_env(temp_db, env)
+    reset_example_runtime_state()
+    migrate_example_database(bootstrap_env)
+
+    app = exampleEntrypoint.get(env=bootstrap_env)
+    api_wrapper = exampleAPI(app)
+    if register_topics:
+        api_wrapper.register_topics()
+    return bootstrap_env, app, api_wrapper
 
 
 class BaseTest:
@@ -16,23 +96,12 @@ class BaseTest:
 
     @classmethod
     def setup_class(cls):
-        cls.env = cls.env.copy()
-        cls.env.update({
-            "SQLALCHEMY_DATABASE_URL": f"sqlite:///{cls.temp_db}",
-            "SCHEMA_NAME": "",
-        })
-        for k, v in cls.env.items():
-            os.environ[k] = v
-        # SQLite no usa esquema, lo eliminamos para evitar confusiones
-        del os.environ["SCHEMA_NAME"]
-
-        clear_topic_cache()
-        # Run migrations using Alembic
-        alembic_cfg = Config("alembic.ini")
-        command.downgrade(alembic_cfg, "base")
-        command.upgrade(alembic_cfg, "head")
-
-        cls.app = exampleEntrypoint.get(env=cls.env)
-        cls.api_wrapper = exampleAPI(cls.app)
-        cls.api_wrapper.register_topics()
+        cls.env, cls.app, cls.api_wrapper = bootstrap_example_stack(
+            cls.temp_db,
+            cls.env.copy(),
+        )
         cls.logger = getLogger(cls.__name__)
+
+    @classmethod
+    def teardown_class(cls):
+        reset_example_runtime_state()

--- a/src/tests/use_cases/contacto/test_marcar_contactado.py
+++ b/src/tests/use_cases/contacto/test_marcar_contactado.py
@@ -47,7 +47,9 @@ class TestMarcarContactado(BaseTest):
 
     @classmethod
     def teardown_class(cls):
-        cls.app.event_bus.shutdown()  # type: ignore
+        shutdown = getattr(cls.app.event_bus, "shutdown", None)
+        if callable(shutdown):
+            shutdown()
         # Cerrar el bus de eventos después de las pruebas
 
     def test_marcar_contactado(self):

--- a/src/tests/use_cases/contacto/test_marcar_contactado.py
+++ b/src/tests/use_cases/contacto/test_marcar_contactado.py
@@ -19,7 +19,7 @@ from example.contacto.domain.contacto import EstadoContacto
 from example.contacto.domain.entidad_contacto import IdEntidadContacto
 from example.contacto.domain.shared import IdEntidad, TipoContacto
 
-from ..base import BaseTest
+from ..base import BaseTest, count_inbox_rows, count_outbox_rows
 
 
 class TestMarcarContactado(BaseTest):
@@ -68,6 +68,8 @@ class TestMarcarContactado(BaseTest):
             contacto=creado.id_contacto,
             usuario=creado.usuario,
         )
+        outbox_before = count_outbox_rows(self.app)
+        inbox_before = count_inbox_rows(self.app, processed=True)
         resp = self.api.publish_and_wait(
             event,
             wait=0.5,
@@ -81,3 +83,6 @@ class TestMarcarContactado(BaseTest):
         # THEN: el contacto se actualiza con estado CONTACTADO y usuario registrado
         contacto = self.api.get(creado.id_contacto.value)
         assert contacto.estado == EstadoContacto.CONTACTADO
+        assert count_outbox_rows(self.app) - outbox_before == 3
+        assert count_outbox_rows(self.app, published=False) == 0
+        assert count_inbox_rows(self.app, processed=True) - inbox_before == 1

--- a/src/tests/use_cases/entidad/test_crear_entidad.py
+++ b/src/tests/use_cases/entidad/test_crear_entidad.py
@@ -101,7 +101,10 @@ class TestCrearEntidad(BaseTest):
 
         ## WHEN: Intentar crear la misma entidad nuevamente
         self.logger.info(
-            "Intentando crear entidad duplicada con cd_asegurado %s y cd_dependiente %s",
+            (
+                "Intentando crear entidad duplicada con "
+                "cd_asegurado %s y cd_dependiente %s"
+            ),
             cd_asegurado,
             cd_dependiente,
         )

--- a/src/tests/use_cases/entidad_contacto/test_crear_entidad_contacto.py
+++ b/src/tests/use_cases/entidad_contacto/test_crear_entidad_contacto.py
@@ -9,3 +9,60 @@ Condiciones posteriores:
     - El estado de validación inicial es NO_VALIDADO.
     - Se emiten los eventos EntidadExamplenapshot y EntidadContactoCreado.
 """
+
+from uuid6 import uuid7
+
+from example.contacto.domain.entidad_contacto import ValidacionEntidadContacto
+from example.contacto.domain.shared import TipoContacto, TipoEntidad
+
+from ..base import BaseTest
+
+
+class TestCrearEntidadContacto(BaseTest):
+    temp_db = __file__.replace(".py", ".db")
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.contacto_api = cls.api_wrapper.contacto.contacto
+        cls.entidad_api = cls.api_wrapper.contacto.entidad
+        cls.api = cls.api_wrapper.contacto.entidad_contacto
+        cls.usuario = uuid7()
+
+    def test_crear_entidad_contacto(self):
+        contacto_resp = self.contacto_api.crear(
+            TipoContacto.EMAIL.value,
+            "entidad-contacto@example.com",
+            usuario=self.usuario,
+        )
+        contacto_creado = contacto_resp.get(self.contacto_api.Events.CREADO.value)
+
+        entidad_resp = self.entidad_api.crear(
+            TipoEntidad.AFILIADO,
+            {
+                "cd_asegurado": "30000001",
+                "cd_dependiente": "01",
+            },
+        )
+        entidad_creada = entidad_resp.get(self.entidad_api.Events.CREADA.value)
+
+        resp = self.api.crear(
+            entidad_creada.id_entidad.value,
+            contacto_creado.id_contacto.value,
+            usuario=self.usuario,
+        )
+
+        creado = resp.get(self.api.Events.CREADO.value, raise_error=False)
+        snapshot = resp.get(self.api.Events.SNAPSHOT.value, raise_error=False)
+
+        assert creado is not None
+        assert snapshot is not None
+
+        entidad_contacto = self.api.get(creado.id_entidad_contacto.value)
+
+        assert entidad_contacto.entidad == entidad_creada.id_entidad
+        assert entidad_contacto.contacto == contacto_creado.id_contacto
+        assert entidad_contacto.validacion == ValidacionEntidadContacto.NO_VALIDADO
+        assert entidad_contacto.usuario_creacion.value == self.usuario
+        assert entidad_contacto.usuario_validacion is None
+        assert entidad_contacto.fecha_validacion is None

--- a/src/tests/use_cases/entidad_contacto/test_validar_entidad_contacto.py
+++ b/src/tests/use_cases/entidad_contacto/test_validar_entidad_contacto.py
@@ -9,3 +9,111 @@ Condiciones posteriores:
     - Se registra el usuario responsable y la fecha de validación.
     - Se emiten los eventos de dominio correspondientes (EntidadContactoCorresponde o EntidadContactoNoCorresponde).
 """
+
+import pytest
+from uuid6 import uuid7
+
+from example.contacto.domain.entidad_contacto import ValidacionEntidadContacto
+from example.contacto.domain.shared import TipoContacto, TipoEntidad
+from hexagonal.domain import DomainValueError
+
+from ..base import BaseTest
+
+
+class TestValidarEntidadContacto(BaseTest):
+    temp_db = __file__.replace(".py", ".db")
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.contacto_api = cls.api_wrapper.contacto.contacto
+        cls.entidad_api = cls.api_wrapper.contacto.entidad
+        cls.api = cls.api_wrapper.contacto.entidad_contacto
+        cls.usuario = uuid7()
+
+    def _crear_entidad_contacto(self, *, suffix: str):
+        contacto_resp = self.contacto_api.crear(
+            TipoContacto.EMAIL.value,
+            f"validar-entidad-contacto-{suffix}@example.com",
+            usuario=self.usuario,
+        )
+        contacto_creado = contacto_resp.get(self.contacto_api.Events.CREADO.value)
+
+        entidad_resp = self.entidad_api.crear(
+            TipoEntidad.AFILIADO,
+            {
+                "cd_asegurado": f"4000000{suffix}",
+                "cd_dependiente": suffix,
+            },
+        )
+        entidad_creada = entidad_resp.get(self.entidad_api.Events.CREADA.value)
+
+        resp = self.api.crear(
+            entidad_creada.id_entidad.value,
+            contacto_creado.id_contacto.value,
+            usuario=self.usuario,
+        )
+        creado = resp.get(self.api.Events.CREADO.value)
+        return entidad_creada, contacto_creado, creado
+
+    def test_validar_entidad_contacto_como_corresponde(self):
+        entidad_creada, contacto_creado, creado = self._crear_entidad_contacto(
+            suffix="1"
+        )
+
+        resp = self.api.validar(
+            entidad_creada.id_entidad.value,
+            contacto_creado.id_contacto.value,
+            ValidacionEntidadContacto.CORRESPONDE,
+            self.usuario,
+        )
+
+        corresponde = resp.get(self.api.Events.CORRESPONDE.value, raise_error=False)
+        snapshot = resp.get(self.api.Events.SNAPSHOT.value, raise_error=False)
+
+        assert corresponde is not None
+        assert snapshot is not None
+
+        entidad_contacto = self.api.get(creado.id_entidad_contacto.value)
+        assert entidad_contacto.validacion == ValidacionEntidadContacto.CORRESPONDE
+        assert entidad_contacto.usuario_validacion.value == self.usuario
+        assert entidad_contacto.fecha_validacion is not None
+
+    def test_validar_entidad_contacto_como_no_corresponde(self):
+        entidad_creada, contacto_creado, creado = self._crear_entidad_contacto(
+            suffix="2"
+        )
+
+        resp = self.api.validar(
+            entidad_creada.id_entidad.value,
+            contacto_creado.id_contacto.value,
+            ValidacionEntidadContacto.NO_CORRESPONDE,
+            self.usuario,
+        )
+
+        no_corresponde = resp.get(
+            self.api.Events.NO_CORRESPONDE.value, raise_error=False
+        )
+        snapshot = resp.get(self.api.Events.SNAPSHOT.value, raise_error=False)
+
+        assert no_corresponde is not None
+        assert snapshot is not None
+
+        entidad_contacto = self.api.get(creado.id_entidad_contacto.value)
+        assert entidad_contacto.validacion == ValidacionEntidadContacto.NO_CORRESPONDE
+        assert entidad_contacto.usuario_validacion.value == self.usuario
+        assert entidad_contacto.fecha_validacion is not None
+
+    def test_validar_entidad_contacto_rechaza_estado_no_validado(self):
+        entidad_creada, contacto_creado, _ = self._crear_entidad_contacto(suffix="3")
+
+        with pytest.raises(
+            DomainValueError,
+            match="La validación debe ser CORRESPONDE o NO_CORRESPONDE",
+        ):
+            self.api.validar(
+                entidad_creada.id_entidad.value,
+                contacto_creado.id_contacto.value,
+                ValidacionEntidadContacto.NO_VALIDADO,
+                self.usuario,
+            )

--- a/src/tests/use_cases/entidad_contacto/test_validar_entidad_contacto.py
+++ b/src/tests/use_cases/entidad_contacto/test_validar_entidad_contacto.py
@@ -1,13 +1,15 @@
 """
 Caso de uso: Validar Entidad Contacto
-Descripción: Valida si un contacto realmente pertenece o corresponde a la entidad vinculada.
+Descripción: Valida si un contacto realmente pertenece o corresponde
+    a la entidad vinculada.
 Condiciones previas:
     - La relación EntidadContacto debe existir previamente.
     - El resultado de validación debe ser CORRESPONDE o NO_CORRESPONDE.
 Condiciones posteriores:
     - El estado de la relación se actualiza según el resultado.
     - Se registra el usuario responsable y la fecha de validación.
-    - Se emiten los eventos de dominio correspondientes (EntidadContactoCorresponde o EntidadContactoNoCorresponde).
+    - Se emiten los eventos de dominio correspondientes
+      (EntidadContactoCorresponde o EntidadContactoNoCorresponde).
 """
 
 import pytest

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "python-hexagonal"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "eventsourcing" },


### PR DESCRIPTION
## Summary
- prepare the `0.3.0` release around the scoped execution refactor for repositories, buses, and UnitOfWork lifecycle
- preserve the practical client contract (`exampleEntrypoint.get(env)` + `exampleAPI(app)`) while moving command, event, and query execution to explicit read/write scopes
- add migration and adoption docs for clients, promote strict verification (`ruff` + `mypy --strict`), and include the supporting skill/docs updates already present on `v0.1.3`

## What changed
- introduced scoped execution contracts and provider-based wiring across repositories, buses, handlers, and SQLAlchemy infrastructure
- updated the example app and use-case tests to validate write-scope isolation, read-scope isolation, queued worker isolation, inbox/outbox behavior, and `publish_and_wait()`
- promoted the SQLAlchemy public integration surface and tightened typing across the library until strict mypy passes
- added `docs/how-to/migrate-to-0.3.0-scoped-execution.md` and updated bootstrap/getting-started/supported-surface docs
- bumped package version from `0.2.0` to `0.3.0`

## Verification
- `uv run pytest src/tests/test_parallel_safe_scopes.py src/tests/test_parallel_dispatch_isolation.py src/tests/use_cases/entidad_contacto/test_crear_entidad_contacto.py src/tests/use_cases/entidad_contacto/test_validar_entidad_contacto.py src/tests/test_example_api_compatibility.py src/tests/use_cases/contacto/test_marcar_contactado.py`
- `uv run pytest src/tests/docs/test_docs_consistency.py src/tests/docs/test_sqlalchemy_public_surface.py -q`
- `uvx ruff check src`
- `set MYPYPATH=src && uvx --from mypy --with pytest --with pydantic --with sqlalchemy --with orjson --with uuid6 --with eventsourcing mypy --strict --python-version 3.12 --namespace-packages --explicit-package-bases --show-error-codes src/hexagonal src/example src/tests`

## Client impact
- clients should stop sharing live `uow` or repository instances across operations
- shared objects should now be limited to datastore/engine, mapper/config, and scope factories/providers
- custom bootstraps should migrate handler wiring toward scope-aware execution instead of singleton mutable write dependencies
- the migration guide is here: `docs/how-to/migrate-to-0.3.0-scoped-execution.md`

## Notes
- this branch already contained skill/docs commits under `.agents/skills/**`; they are included in the PR because they are part of the current `v0.1.3` branch history
- non-blocking caveats remain documented from verify: SQLAlchemy emits a runtime `SAWarning` in one queued-worker path, and datastore `start_connection()` still carries a pragmatic `Any` boundary