### PR TITLE
fix: scope outbox publishing to active repository

### DIFF
--- a/src/hexagonal/adapters/drivens/buses/base/message_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/message_bus.py
@@ -46,33 +46,47 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
 
     def save_to_outbox(self, *messages: CloudMessage[Any]) -> None:
         self.verify()
-        if self._write_scope_runner is None or self._outbox_repository_getter is None:
-            self.outbox_repository.save(*messages)
-            return
-        outbox_repository_getter = self._outbox_repository_getter
-
-        scope = self._write_scope_runner.current_write_scope
-        if scope is not None:
-            outbox_repository_getter(scope).save(*messages)
-            return
-
-        self._write_scope_runner.run_in_write_scope(
-            lambda write_scope: outbox_repository_getter(write_scope).save(*messages)
+        self._run_with_outbox_repository(
+            lambda outbox_repository: outbox_repository.save(*messages)
         )
 
     # publish
     def publish_from_outbox(self, limit: int | None = None) -> None:
         self.verify()
-        messages = self.outbox_repository.fetch_pending(limit=limit)
-        self._publish_messages(*messages)
+        self._run_with_outbox_repository(
+            lambda outbox_repository: self._publish_messages(
+                outbox_repository,
+                *outbox_repository.fetch_pending(limit=limit),
+            )
+        )
 
-    def _publish_messages(self, *messages: CloudMessage[Any]) -> None:
+    def _run_with_outbox_repository(
+        self,
+        work: Callable[[IOutboxRepository[TManager]], Any],
+    ) -> Any:
+        if self._write_scope_runner is None or self._outbox_repository_getter is None:
+            return work(self.outbox_repository)
+
+        outbox_repository_getter = self._outbox_repository_getter
+        scope = self._write_scope_runner.current_write_scope
+        if scope is not None:
+            return work(outbox_repository_getter(scope))
+
+        return self._write_scope_runner.run_in_write_scope(
+            lambda write_scope: work(outbox_repository_getter(write_scope))
+        )
+
+    def _publish_messages(
+        self,
+        outbox_repository: IOutboxRepository[TManager],
+        *messages: CloudMessage[Any],
+    ) -> None:
         for message in messages:
             try:
                 self._publish_message(message)
-                self.outbox_repository.mark_as_published(message.message_id)
+                outbox_repository.mark_as_published(message.message_id)
             except Exception as e:
-                self.outbox_repository.mark_as_failed(message.message_id, error=str(e))
+                outbox_repository.mark_as_failed(message.message_id, error=str(e))
 
     @abstractmethod
     def _publish_message(self, message: CloudMessage[Any]) -> None: ...

--- a/src/tests/test_parallel_dispatch_isolation.py
+++ b/src/tests/test_parallel_dispatch_isolation.py
@@ -1,5 +1,6 @@
 import threading
 from pathlib import Path
+from typing import Any, cast
 
 from example.contacto.domain.shared import TipoContacto
 from tests.use_cases.base import bootstrap_example_stack
@@ -11,7 +12,7 @@ def test_write_scope_runner_isolates_worker_threads(tmp_path: Path):
         {"ENV_BUS": "inmemory"},
     )
 
-    runner = app.bus_app.infrastructure.write_scope_runner
+    runner = cast(Any, app.bus_app).infrastructure.write_scope_runner
     seen: dict[str, tuple[int, int, int]] = {}
 
     seen["main"] = runner.run_in_write_scope(
@@ -50,7 +51,7 @@ def test_write_scope_runner_reuses_same_scope_for_nested_same_thread_work(tmp_pa
         {"ENV_BUS": "inmemory"},
     )
 
-    runner = app.bus_app.infrastructure.write_scope_runner
+    runner = cast(Any, app.bus_app).infrastructure.write_scope_runner
 
     def outer(scope):
         current_scope_ids = (id(scope.uow), id(scope.uow.connection_manager))
@@ -76,7 +77,9 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
         },
     )
 
-    runner = app.bus_app.infrastructure.write_scope_runner
+    runner = cast(Any, app.bus_app).infrastructure.write_scope_runner
+    command_bus = cast(Any, app.command_bus)
+    event_bus = cast(Any, app.event_bus)
     main_scope = runner.run_in_write_scope(
         lambda scope: (
             threading.get_ident(),
@@ -86,7 +89,12 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
     )
 
     created_scopes: list[tuple[int, int, int]] = []
+    scoped_publish_usage: list[tuple[int, str, int, int]] = []
+    root_publish_usage: list[str] = []
     original_create_write_scope = runner._create_write_scope
+    root_outbox = command_bus.outbox_repository
+    original_root_fetch_pending = root_outbox.fetch_pending
+    original_root_mark_as_published = root_outbox.mark_as_published
 
     def record_write_scope():
         scope = original_create_write_scope()
@@ -97,9 +105,47 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
                 id(scope.uow.connection_manager),
             )
         )
+        scope_outbox = scope.outbox_repository
+        original_scope_fetch_pending = scope_outbox.fetch_pending
+        original_scope_mark_as_published = scope_outbox.mark_as_published
+
+        def scope_fetch_pending(*args, **kwargs):
+            scoped_publish_usage.append(
+                (
+                    threading.get_ident(),
+                    "fetch",
+                    id(scope.uow),
+                    id(scope_outbox),
+                )
+            )
+            return original_scope_fetch_pending(*args, **kwargs)
+
+        def scope_mark_as_published(*message_ids):
+            scoped_publish_usage.append(
+                (
+                    threading.get_ident(),
+                    "mark",
+                    id(scope.uow),
+                    id(scope_outbox),
+                )
+            )
+            return original_scope_mark_as_published(*message_ids)
+
+        scope_outbox.fetch_pending = scope_fetch_pending
+        scope_outbox.mark_as_published = scope_mark_as_published
         return scope
 
+    def root_fetch_pending(*args, **kwargs):
+        root_publish_usage.append("fetch")
+        return original_root_fetch_pending(*args, **kwargs)
+
+    def root_mark_as_published(*message_ids):
+        root_publish_usage.append("mark")
+        return original_root_mark_as_published(*message_ids)
+
     runner._create_write_scope = record_write_scope
+    root_outbox.fetch_pending = root_fetch_pending
+    root_outbox.mark_as_published = root_mark_as_published
     created_event = {}
     contacto_api = api.contacto.contacto
 
@@ -119,9 +165,9 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
 
         assert response.has_events is False
 
-        app.command_bus.publish_from_outbox()
-        app.command_bus.queue.join()
-        app.event_bus.queue.join()
+        command_bus.publish_from_outbox()
+        command_bus.queue.join()
+        event_bus.queue.join()
 
         created = created_event.get("value")
         assert created is not None
@@ -131,11 +177,30 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
         )
 
         worker_scopes = [scope for scope in created_scopes if scope[0] != main_scope[0]]
+        publish_scopes = [
+            scope for scope in created_scopes if scope[1] != main_scope[1]
+        ]
+        main_thread_publish_usage = [
+            entry for entry in scoped_publish_usage if entry[0] == main_scope[0]
+        ]
 
         assert worker_scopes
         assert all(scope[1] != main_scope[1] for scope in worker_scopes)
         assert all(scope[2] != main_scope[2] for scope in worker_scopes)
+        assert root_publish_usage == []
+        assert [operation for _, operation, _, _ in main_thread_publish_usage] == [
+            "fetch",
+            "mark",
+        ]
+        assert publish_scopes
+        assert all(scope[1] != main_scope[1] for scope in publish_scopes)
+        assert (
+            len({repository_id for _, _, _, repository_id in main_thread_publish_usage})
+            == 1
+        )
     finally:
         runner._create_write_scope = original_create_write_scope
-        app.command_bus.shutdown()
-        app.event_bus.shutdown()
+        root_outbox.fetch_pending = original_root_fetch_pending
+        root_outbox.mark_as_published = original_root_mark_as_published
+        command_bus.shutdown()
+        event_bus.shutdown()

--- a/src/tests/test_parallel_dispatch_isolation.py
+++ b/src/tests/test_parallel_dispatch_isolation.py
@@ -78,8 +78,84 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
     )
 
     runner = cast(Any, app.bus_app).infrastructure.write_scope_runner
+    main_scope = runner.run_in_write_scope(
+        lambda scope: (
+            threading.get_ident(),
+            id(scope.uow),
+            id(scope.uow.connection_manager),
+        )
+    )
+
+    created_scopes: list[tuple[int, int, int]] = []
+    original_create_write_scope = runner._create_write_scope
+
+    def record_write_scope():
+        scope = original_create_write_scope()
+        created_scopes.append(
+            (
+                threading.get_ident(),
+                id(scope.uow),
+                id(scope.uow.connection_manager),
+            )
+        )
+        return scope
+
+    runner._create_write_scope = record_write_scope
+    created_event = {}
+    contacto_api = api.contacto.contacto
     command_bus = cast(Any, app.command_bus)
     event_bus = cast(Any, app.event_bus)
+
+    command_bus.consume()
+    event_bus.consume()
+    event_bus.wait_for_publish(
+        contacto_api.Events.CREADO.value,
+        lambda event: created_event.setdefault("value", event),
+    )
+
+    try:
+        response = contacto_api.crear(
+            TipoContacto.EMAIL.value,
+            "queued-worker@example.com",
+            async_dispatch=True,
+        )
+
+        assert response.has_events is False
+
+        command_bus.publish_from_outbox()
+        command_bus.queue.join()
+        event_bus.queue.join()
+
+        created = created_event.get("value")
+        assert created is not None
+        assert (
+            contacto_api.get(created.id_contacto.value).contacto.value
+            == "queued-worker@example.com"
+        )
+
+        worker_scopes = [scope for scope in created_scopes if scope[0] != main_scope[0]]
+
+        assert worker_scopes
+        assert all(scope[1] != main_scope[1] for scope in worker_scopes)
+        assert all(scope[2] != main_scope[2] for scope in worker_scopes)
+    finally:
+        runner._create_write_scope = original_create_write_scope
+        command_bus.shutdown()
+        event_bus.shutdown()
+
+
+def test_queued_command_publish_from_outbox_uses_scoped_repository(tmp_path: Path):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-dispatch-command-publish-routing.db",
+        {
+            "ENV_BUS": "inmemory_queue",
+            "EVENT_BUS_WORKER_DAEMON": "false",
+        },
+    )
+
+    runner = cast(Any, app.bus_app).infrastructure.write_scope_runner
+    command_bus = cast(Any, app.command_bus)
+    contacto_api = api.contacto.contacto
     main_scope = runner.run_in_write_scope(
         lambda scope: (
             threading.get_ident(),
@@ -91,7 +167,9 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
     created_scopes: list[tuple[int, int, int]] = []
     scoped_publish_usage: list[tuple[int, str, int, int]] = []
     root_publish_usage: list[str] = []
+    published_ids: list[object] = []
     original_create_write_scope = runner._create_write_scope
+    original_publish_message = command_bus._publish_message
     root_outbox = command_bus.outbox_repository
     original_root_fetch_pending = root_outbox.fetch_pending
     original_root_mark_as_published = root_outbox.mark_as_published
@@ -143,64 +221,42 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
         root_publish_usage.append("mark")
         return original_root_mark_as_published(*message_ids)
 
+    def publish_message_noop(message):
+        published_ids.append(message.message_id)
+
     runner._create_write_scope = record_write_scope
+    command_bus._publish_message = publish_message_noop
     root_outbox.fetch_pending = root_fetch_pending
     root_outbox.mark_as_published = root_mark_as_published
-    created_event = {}
-    contacto_api = api.contacto.contacto
-
-    app.command_bus.consume()
-    app.event_bus.consume()
-    app.event_bus.wait_for_publish(
-        contacto_api.Events.CREADO.value,
-        lambda event: created_event.setdefault("value", event),
-    )
 
     try:
         response = contacto_api.crear(
             TipoContacto.EMAIL.value,
-            "queued-worker@example.com",
+            "queued-publish-routing@example.com",
             async_dispatch=True,
         )
 
         assert response.has_events is False
 
         command_bus.publish_from_outbox()
-        command_bus.queue.join()
-        event_bus.queue.join()
 
-        created = created_event.get("value")
-        assert created is not None
-        assert (
-            contacto_api.get(created.id_contacto.value).contacto.value
-            == "queued-worker@example.com"
-        )
-
-        worker_scopes = [scope for scope in created_scopes if scope[0] != main_scope[0]]
         publish_scopes = [
-            scope for scope in created_scopes if scope[1] != main_scope[1]
-        ]
-        main_thread_publish_usage = [
-            entry for entry in scoped_publish_usage if entry[0] == main_scope[0]
+            scope for scope in created_scopes if scope[0] == main_scope[0]
         ]
 
-        assert worker_scopes
-        assert all(scope[1] != main_scope[1] for scope in worker_scopes)
-        assert all(scope[2] != main_scope[2] for scope in worker_scopes)
+        assert published_ids
         assert root_publish_usage == []
-        assert [operation for _, operation, _, _ in main_thread_publish_usage] == [
+        assert [operation for _, operation, _, _ in scoped_publish_usage] == [
             "fetch",
             "mark",
         ]
         assert publish_scopes
         assert all(scope[1] != main_scope[1] for scope in publish_scopes)
         assert (
-            len({repository_id for _, _, _, repository_id in main_thread_publish_usage})
-            == 1
+            len({repository_id for _, _, _, repository_id in scoped_publish_usage}) == 1
         )
     finally:
         runner._create_write_scope = original_create_write_scope
+        command_bus._publish_message = original_publish_message
         root_outbox.fetch_pending = original_root_fetch_pending
         root_outbox.mark_as_published = original_root_mark_as_published
-        command_bus.shutdown()
-        event_bus.shutdown()

--- a/src/tests/test_parallel_safe_scopes.py
+++ b/src/tests/test_parallel_safe_scopes.py
@@ -1,3 +1,7 @@
+from typing import Any, cast
+
+from hexagonal.domain import CloudMessage
+
 from example.contacto.domain.shared import TipoContacto
 from tests.use_cases.base import (
     bootstrap_example_stack,
@@ -14,7 +18,7 @@ def test_write_scopes_create_fresh_mutable_objects_and_reuse_cached_primitives(
         {"ENV_BUS": "inmemory"},
     )
 
-    infrastructure = app.bus_app.infrastructure
+    infrastructure = cast(Any, app.bus_app).infrastructure
 
     first_scope = infrastructure.create_write_scope()
     second_scope = infrastructure.create_write_scope()
@@ -65,13 +69,284 @@ def test_scoped_command_execution_publishes_without_leaking_pending_outbox_rows(
     assert count_inbox_rows(app, processed=True) - before_inbox_processed == 1
 
 
+def test_publish_from_outbox_uses_current_write_scope_outbox_repository(tmp_path):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-safe-scope-publish-routing.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    contacto_api = api.contacto.contacto
+    created = contacto_api.crear(
+        TipoContacto.EMAIL.value,
+        "scope-routing@example.com",
+    ).get(contacto_api.Events.CREADO.value)
+    message = CloudMessage[type(created)].new(created)
+
+    event_bus = cast(Any, app.event_bus)
+    root_outbox = event_bus.outbox_repository
+    runner = cast(Any, app.bus_app).infrastructure.write_scope_runner
+    root_usage: list[str] = []
+    scope_usage: list[str] = []
+    published_ids: list[object] = []
+
+    original_publish_message = event_bus._publish_message
+
+    def publish_message_noop(cloud_message):
+        published_ids.append(cloud_message.message_id)
+
+    event_bus._publish_message = publish_message_noop
+
+    def exercise(scope):
+        scope_outbox = scope.outbox_repository
+        original_root_fetch_pending = root_outbox.fetch_pending
+        original_root_mark_as_published = root_outbox.mark_as_published
+        original_scope_fetch_pending = scope_outbox.fetch_pending
+        original_scope_mark_as_published = scope_outbox.mark_as_published
+
+        def root_fetch_pending(*args, **kwargs):
+            root_usage.append("fetch")
+            return [message]
+
+        def root_mark_as_published(*message_ids):
+            root_usage.append("mark")
+            return original_root_mark_as_published(*message_ids)
+
+        def scope_fetch_pending(*args, **kwargs):
+            scope_usage.append("fetch")
+            return [message]
+
+        def scope_mark_as_published(*message_ids):
+            scope_usage.append("mark")
+            return original_scope_mark_as_published(*message_ids)
+
+        root_outbox.fetch_pending = root_fetch_pending
+        root_outbox.mark_as_published = root_mark_as_published
+        scope_outbox.fetch_pending = scope_fetch_pending
+        scope_outbox.mark_as_published = scope_mark_as_published
+
+        try:
+            event_bus.publish_from_outbox(limit=1)
+        finally:
+            root_outbox.fetch_pending = original_root_fetch_pending
+            root_outbox.mark_as_published = original_root_mark_as_published
+            scope_outbox.fetch_pending = original_scope_fetch_pending
+            scope_outbox.mark_as_published = original_scope_mark_as_published
+
+    try:
+        runner.run_in_write_scope(exercise)
+    finally:
+        event_bus._publish_message = original_publish_message
+
+    assert published_ids == [message.message_id]
+    assert root_usage == []
+    assert scope_usage == ["fetch", "mark"]
+
+
+def test_publish_from_outbox_marks_failure_with_current_write_scope_outbox_repository(
+    tmp_path,
+):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-safe-scope-publish-failure-routing.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    contacto_api = api.contacto.contacto
+    created = contacto_api.crear(
+        TipoContacto.EMAIL.value,
+        "scope-routing-failure@example.com",
+    ).get(contacto_api.Events.CREADO.value)
+    message = CloudMessage[type(created)].new(created)
+
+    event_bus = cast(Any, app.event_bus)
+    root_outbox = event_bus.outbox_repository
+    runner = cast(Any, app.bus_app).infrastructure.write_scope_runner
+    root_usage: list[str] = []
+    scope_usage: list[str] = []
+    captured_errors: list[str] = []
+
+    original_publish_message = event_bus._publish_message
+
+    def publish_message_boom(cloud_message):
+        raise RuntimeError(f"boom:{cloud_message.message_id}")
+
+    event_bus._publish_message = publish_message_boom
+
+    def exercise(scope):
+        scope_outbox = scope.outbox_repository
+        original_root_fetch_pending = root_outbox.fetch_pending
+        original_root_mark_as_failed = root_outbox.mark_as_failed
+        original_scope_fetch_pending = scope_outbox.fetch_pending
+        original_scope_mark_as_failed = scope_outbox.mark_as_failed
+
+        def root_fetch_pending(*args, **kwargs):
+            root_usage.append("fetch")
+            return [message]
+
+        def root_mark_as_failed(*message_ids, error):
+            root_usage.append("fail")
+
+        def scope_fetch_pending(*args, **kwargs):
+            scope_usage.append("fetch")
+            return [message]
+
+        def scope_mark_as_failed(*message_ids, error):
+            scope_usage.append("fail")
+            captured_errors.append(error)
+
+        root_outbox.fetch_pending = root_fetch_pending
+        root_outbox.mark_as_failed = root_mark_as_failed
+        scope_outbox.fetch_pending = scope_fetch_pending
+        scope_outbox.mark_as_failed = scope_mark_as_failed
+
+        try:
+            event_bus.publish_from_outbox(limit=1)
+        finally:
+            root_outbox.fetch_pending = original_root_fetch_pending
+            root_outbox.mark_as_failed = original_root_mark_as_failed
+            scope_outbox.fetch_pending = original_scope_fetch_pending
+            scope_outbox.mark_as_failed = original_scope_mark_as_failed
+
+    try:
+        runner.run_in_write_scope(exercise)
+    finally:
+        event_bus._publish_message = original_publish_message
+
+    assert root_usage == []
+    assert scope_usage == ["fetch", "fail"]
+    assert captured_errors == [f"boom:{message.message_id}"]
+
+
+def test_publish_from_outbox_without_active_scope_creates_fresh_write_scope(tmp_path):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-safe-scope-publish-fresh-scope.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    contacto_api = api.contacto.contacto
+    created = contacto_api.crear(
+        TipoContacto.EMAIL.value,
+        "scope-routing-fresh-scope@example.com",
+    ).get(contacto_api.Events.CREADO.value)
+    message = CloudMessage[type(created)].new(created)
+
+    event_bus = cast(Any, app.event_bus)
+    root_outbox = event_bus.outbox_repository
+    runner = cast(Any, app.bus_app).infrastructure.write_scope_runner
+    root_usage: list[str] = []
+    scope_usage: list[tuple[str, int]] = []
+    created_scope_ids: list[int] = []
+    published_ids: list[object] = []
+
+    original_publish_message = event_bus._publish_message
+    original_create_write_scope = runner._create_write_scope
+    original_root_fetch_pending = root_outbox.fetch_pending
+    original_root_mark_as_published = root_outbox.mark_as_published
+
+    def publish_message_noop(cloud_message):
+        published_ids.append(cloud_message.message_id)
+
+    def record_write_scope():
+        scope = original_create_write_scope()
+        created_scope_ids.append(id(scope))
+        scope_outbox = scope.outbox_repository
+        original_scope_fetch_pending = scope_outbox.fetch_pending
+        original_scope_mark_as_published = scope_outbox.mark_as_published
+
+        def scope_fetch_pending(*args, **kwargs):
+            scope_usage.append(("fetch", id(scope_outbox)))
+            return [message]
+
+        def scope_mark_as_published(*message_ids):
+            scope_usage.append(("mark", id(scope_outbox)))
+
+        scope_outbox.fetch_pending = scope_fetch_pending
+        scope_outbox.mark_as_published = scope_mark_as_published
+        return scope
+
+    def root_fetch_pending(*args, **kwargs):
+        root_usage.append("fetch")
+        return [message]
+
+    def root_mark_as_published(*message_ids):
+        root_usage.append("mark")
+
+    runner._create_write_scope = record_write_scope
+    event_bus._publish_message = publish_message_noop
+    root_outbox.fetch_pending = root_fetch_pending
+    root_outbox.mark_as_published = root_mark_as_published
+
+    try:
+        event_bus.publish_from_outbox(limit=1)
+    finally:
+        runner._create_write_scope = original_create_write_scope
+        event_bus._publish_message = original_publish_message
+        root_outbox.fetch_pending = original_root_fetch_pending
+        root_outbox.mark_as_published = original_root_mark_as_published
+
+    assert published_ids == [message.message_id]
+    assert len(created_scope_ids) == 1
+    assert root_usage == []
+    assert [operation for operation, _ in scope_usage] == ["fetch", "mark"]
+    assert len({repository_id for _, repository_id in scope_usage}) == 1
+
+
+def test_publish_from_outbox_without_scope_runtime_falls_back_to_root_repository(
+    tmp_path,
+):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-safe-scope-publish-root-fallback.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    contacto_api = api.contacto.contacto
+    created = contacto_api.crear(
+        TipoContacto.EMAIL.value,
+        "scope-routing-root-fallback@example.com",
+    ).get(contacto_api.Events.CREADO.value)
+    message = CloudMessage[type(created)].new(created)
+
+    event_bus = cast(Any, app.event_bus)
+    event_bus.configure_scope_runtime()
+    root_outbox = event_bus.outbox_repository
+    root_usage: list[str] = []
+    published_ids: list[object] = []
+
+    original_publish_message = event_bus._publish_message
+    original_root_fetch_pending = root_outbox.fetch_pending
+    original_root_mark_as_published = root_outbox.mark_as_published
+
+    def publish_message_noop(cloud_message):
+        published_ids.append(cloud_message.message_id)
+
+    def root_fetch_pending(*args, **kwargs):
+        root_usage.append("fetch")
+        return [message]
+
+    def root_mark_as_published(*message_ids):
+        root_usage.append("mark")
+
+    event_bus._publish_message = publish_message_noop
+    root_outbox.fetch_pending = root_fetch_pending
+    root_outbox.mark_as_published = root_mark_as_published
+
+    try:
+        event_bus.publish_from_outbox(limit=1)
+    finally:
+        event_bus._publish_message = original_publish_message
+        root_outbox.fetch_pending = original_root_fetch_pending
+        root_outbox.mark_as_published = original_root_mark_as_published
+
+    assert published_ids == [message.message_id]
+    assert root_usage == ["fetch", "mark"]
+
+
 def test_read_scopes_create_fresh_managers_and_repositories(tmp_path):
     _, app, _ = bootstrap_example_stack(
         tmp_path / "parallel-safe-read-scopes.db",
         {"ENV_BUS": "inmemory"},
     )
 
-    infrastructure = app.bus_app.infrastructure
+    infrastructure = cast(Any, app.bus_app).infrastructure
     runner = infrastructure.read_scope_runner
 
     first_scope = runner.run_in_read_scope(


### PR DESCRIPTION
## Summary
- centralize outbox repository resolution so scoped publish uses the same repository for fetch, success marking, and failure marking
- run the full publish cycle inside a fresh write scope when scoped runtime is configured without an active scope
- add regression tests for scoped routing, worker isolation, fallback behavior, and verify the full pytest suite passes

## Verification
- uv run pytest