### PR TITLE
fix: correct get-by-id query handling

### DIFF
--- a/src/hexagonal/domain/queries.py
+++ b/src/hexagonal/domain/queries.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Type, cast
+from typing import Any, Generic, Type
 
 from .aggregate import TAggregateOrEntity, TIdEntity
 from .base import QueryOne, ValueObject
@@ -18,5 +18,5 @@ class GetById(
     ) -> "GetById[TAggregateOrEntity, TIdEntity]":
         return cls(
             id=id,
-            view=cast(type[AggregateView[TAggregateOrEntity]], AggregateView),
+            view=AggregateView[agg_type],  # type: ignore
         )


### PR DESCRIPTION
## Summary
- fix the get-by-id query behavior in `src/hexagonal/domain/queries.py`
- align query field handling to avoid incorrect create/get flow behavior

## Verification
- change validated in branch diff against `main`