### PR TITLE
fix: stabilize sqlite threading datastore transactions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,7 @@ jobs:
         run: uv sync --frozen --group dev
 
       - name: Run test suite
-        run: uv run pytest -q
+        run: uv run pytest -q --ignore=src/tests/use_cases
+
+      - name: Run use case tests
+        run: uv run pytest -q src/tests/use_cases

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+*.db*

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
@@ -109,8 +109,8 @@ class SQLAlchemyDatastore:
             if self._database_url.startswith("sqlite"):
                 connection.execute(text("PRAGMA foreign_keys = ON"))
                 connection.execute(text("PRAGMA busy_timeout = 30000"))
-                connection.execute(text("PRAGMA journal_mode = WAL"))
-                connection.execute(text("PRAGMA synchronous = NORMAL"))
+                # connection.execute(text("PRAGMA journal_mode = WAL"))
+                # connection.execute(text("PRAGMA synchronous = NORMAL"))
             yield connection
 
     @contextmanager

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
@@ -109,6 +109,8 @@ class SQLAlchemyDatastore:
             if self._database_url.startswith("sqlite"):
                 connection.execute(text("PRAGMA foreign_keys = ON"))
                 connection.execute(text("PRAGMA busy_timeout = 30000"))
+                connection.execute(text("PRAGMA journal_mode = WAL"))
+                connection.execute(text("PRAGMA synchronous = NORMAL"))
             yield connection
 
     @contextmanager

--- a/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
+++ b/src/hexagonal/adapters/drivens/repository/sqlalchemy/datastore.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 from eventsourcing.utils import strtobool
 from sqlalchemy import Connection, Engine, create_engine, text
-from sqlalchemy.pool import QueuePool, StaticPool
+from sqlalchemy.pool import QueuePool
 
 from hexagonal.ports.drivens.repository import IConnectionManager
 
@@ -52,26 +52,31 @@ class SQLAlchemyDatastore:
         """
         self._database_url = database_url
 
-        # SQLite uses StaticPool for single connection (avoids database lock issues)
-        # Other databases use QueuePool with configurable settings
+        # Use QueuePool across all backends.
+        # For SQLite this allows multiple pooled connections, which is required
+        # for concurrent test scenarios.
         is_sqlite = database_url.startswith("sqlite")
 
-        pool_class = StaticPool if is_sqlite else QueuePool
+        pool_class = QueuePool
         pool_kwargs: dict[Any, Any] = {}
 
         if is_sqlite:
-            # For SQLite with StaticPool, we need connect_args
-            pool_kwargs["connect_args"] = {"check_same_thread": False}
-        else:
-            pool_kwargs.update(
-                {
-                    "pool_size": pool_size,
-                    "pool_timeout": pool_timeout,
-                    "pool_recycle": pool_recycle,
-                    "pool_pre_ping": pool_pre_ping,
-                    "max_overflow": max_overflow,
-                }
-            )
+            # SQLite connections are thread-affine by default.
+            # Disable the thread check so pooled connections can be used by
+            # different worker threads in tests.
+            pool_kwargs["connect_args"] = {
+                "check_same_thread": False,
+                "timeout": pool_timeout,
+            }
+        pool_kwargs.update(
+            {
+                "pool_size": pool_size,
+                "pool_timeout": pool_timeout,
+                "pool_recycle": pool_recycle,
+                "pool_pre_ping": pool_pre_ping,
+                "max_overflow": max_overflow,
+            }
+        )
 
         self._engine: Engine = create_engine(
             database_url,
@@ -103,6 +108,7 @@ class SQLAlchemyDatastore:
             # Enable foreign key support for SQLite
             if self._database_url.startswith("sqlite"):
                 connection.execute(text("PRAGMA foreign_keys = ON"))
+                connection.execute(text("PRAGMA busy_timeout = 30000"))
             yield connection
 
     @contextmanager
@@ -152,6 +158,7 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
         self._datastore = datastore
         self._current_connection: Optional[Connection] = None
         self._connection_ctx: Optional[AbstractContextManager[Connection]] = None
+        self._uow_managed_connection = False
         self._initialized = datastore is not None
 
     @property
@@ -227,6 +234,7 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
         """
         self._connection_ctx = self.datastore.get_connection()
         self._current_connection = self._connection_ctx.__enter__()
+        self._uow_managed_connection = True
         return self._connection_ctx
 
     @property
@@ -240,6 +248,7 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
             If no connection exists or it's closed, a new one will be created.
         #"""
         if self._current_connection is None or self._current_connection.closed:
+            self.current_connection = None
             self._connection_ctx = self.datastore.get_connection()
             self._current_connection = self._connection_ctx.__enter__()
         if self._current_connection is None:
@@ -259,6 +268,7 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
             except Exception:
                 pass  # Ignore errors during cleanup
             self._connection_ctx = None
+        self._uow_managed_connection = False
         self._current_connection = connection
 
     @contextmanager
@@ -276,16 +286,19 @@ class SQLAlchemyConnectionContextManager(IConnectionManager):
         Yields:
             Current connection for executing statements
         """
-        try:
-            # Check if connection is usable
-            conn = self.current_connection
-            if conn.closed:
-                self._current_connection = None
+        if self._uow_managed_connection:
+            try:
                 conn = self.current_connection
+                if conn.closed:
+                    self.current_connection = None
+                    conn = self.current_connection
+                yield conn
+            except Exception:
+                self.current_connection = None
+                raise
+            return
+
+        with self.datastore.get_connection() as conn:
             yield conn
             if commit and conn.in_transaction():
                 conn.commit()
-        except Exception:
-            # Reset connection on error
-            self._current_connection = None
-            raise

--- a/src/tests/test_example_api_compatibility.py
+++ b/src/tests/test_example_api_compatibility.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from example import exampleEntrypoint
 from example.app.entrypoints.db.sqlalchemy import SQLAlchemyexampleEntrypoint
 from example.app.entrypoints.main import exampleEntrypoint as main_example_entrypoint
@@ -11,7 +13,7 @@ from tests.use_cases.base import (
 )
 
 
-def test_public_example_exports_keep_bootstrap_contract(tmp_path):
+def test_public_example_exports_keep_bootstrap_contract(tmp_path: Path):
     assert exampleEntrypoint is main_example_entrypoint
 
     _, app, api = bootstrap_example_stack(
@@ -36,7 +38,7 @@ def test_public_example_exports_keep_bootstrap_contract(tmp_path):
     assert count_outbox_rows(app, published=False) == 0
 
 
-def test_sqlalchemy_example_entrypoint_still_builds_a_bus_app(tmp_path):
+def test_sqlalchemy_example_entrypoint_still_builds_a_bus_app(tmp_path: Path):
     env = build_example_env(
         tmp_path / "example-db-entrypoint-compatibility.db",
         {"ENV_BUS": "inmemory"},

--- a/src/tests/test_parallel_safe_scopes.py
+++ b/src/tests/test_parallel_safe_scopes.py
@@ -1,8 +1,8 @@
+from pathlib import Path
 from typing import Any, cast
 
-from hexagonal.domain import CloudMessage
-
 from example.contacto.domain.shared import TipoContacto
+from hexagonal.domain import CloudMessage
 from tests.use_cases.base import (
     bootstrap_example_stack,
     count_inbox_rows,
@@ -11,7 +11,7 @@ from tests.use_cases.base import (
 
 
 def test_write_scopes_create_fresh_mutable_objects_and_reuse_cached_primitives(
-    tmp_path,
+    tmp_path: Path,
 ):
     _, app, _ = bootstrap_example_stack(
         tmp_path / "parallel-safe-scopes.db",
@@ -50,7 +50,7 @@ def test_write_scopes_create_fresh_mutable_objects_and_reuse_cached_primitives(
 
 
 def test_scoped_command_execution_publishes_without_leaking_pending_outbox_rows(
-    tmp_path,
+    tmp_path: Path,
 ):
     _, app, api = bootstrap_example_stack(
         tmp_path / "parallel-safe-scope-outbox.db",
@@ -69,7 +69,7 @@ def test_scoped_command_execution_publishes_without_leaking_pending_outbox_rows(
     assert count_inbox_rows(app, processed=True) - before_inbox_processed == 1
 
 
-def test_publish_from_outbox_uses_current_write_scope_outbox_repository(tmp_path):
+def test_publish_from_outbox_uses_current_write_scope_outbox_repository(tmp_path: Path):
     _, app, api = bootstrap_example_stack(
         tmp_path / "parallel-safe-scope-publish-routing.db",
         {"ENV_BUS": "inmemory"},
@@ -143,7 +143,7 @@ def test_publish_from_outbox_uses_current_write_scope_outbox_repository(tmp_path
 
 
 def test_publish_from_outbox_marks_failure_with_current_write_scope_outbox_repository(
-    tmp_path,
+    tmp_path: Path,
 ):
     _, app, api = bootstrap_example_stack(
         tmp_path / "parallel-safe-scope-publish-failure-routing.db",
@@ -216,7 +216,9 @@ def test_publish_from_outbox_marks_failure_with_current_write_scope_outbox_repos
     assert captured_errors == [f"boom:{message.message_id}"]
 
 
-def test_publish_from_outbox_without_active_scope_creates_fresh_write_scope(tmp_path):
+def test_publish_from_outbox_without_active_scope_creates_fresh_write_scope(
+    tmp_path: Path,
+):
     _, app, api = bootstrap_example_stack(
         tmp_path / "parallel-safe-scope-publish-fresh-scope.db",
         {"ENV_BUS": "inmemory"},
@@ -291,7 +293,7 @@ def test_publish_from_outbox_without_active_scope_creates_fresh_write_scope(tmp_
 
 
 def test_publish_from_outbox_without_scope_runtime_falls_back_to_root_repository(
-    tmp_path,
+    tmp_path: Path,
 ):
     _, app, api = bootstrap_example_stack(
         tmp_path / "parallel-safe-scope-publish-root-fallback.db",
@@ -315,14 +317,14 @@ def test_publish_from_outbox_without_scope_runtime_falls_back_to_root_repository
     original_root_fetch_pending = root_outbox.fetch_pending
     original_root_mark_as_published = root_outbox.mark_as_published
 
-    def publish_message_noop(cloud_message):
+    def publish_message_noop(cloud_message: CloudMessage[Any]):
         published_ids.append(cloud_message.message_id)
 
-    def root_fetch_pending(*args, **kwargs):
+    def root_fetch_pending(*args: Any, **kwargs: Any):
         root_usage.append("fetch")
         return [message]
 
-    def root_mark_as_published(*message_ids):
+    def root_mark_as_published(*message_ids: Any):
         root_usage.append("mark")
 
     event_bus._publish_message = publish_message_noop
@@ -340,7 +342,7 @@ def test_publish_from_outbox_without_scope_runtime_falls_back_to_root_repository
     assert root_usage == ["fetch", "mark"]
 
 
-def test_read_scopes_create_fresh_managers_and_repositories(tmp_path):
+def test_read_scopes_create_fresh_managers_and_repositories(tmp_path: Path):
     _, app, _ = bootstrap_example_stack(
         tmp_path / "parallel-safe-read-scopes.db",
         {"ENV_BUS": "inmemory"},

--- a/src/tests/use_cases/test_threading_use.py
+++ b/src/tests/use_cases/test_threading_use.py
@@ -1,0 +1,75 @@
+import threading
+from queue import Queue
+from typing import Any
+
+from example.contacto.application import ContactoAppAPI
+from example.contacto.domain.contacto import TipoContacto
+
+from .base import BaseTest
+
+
+class TestThreadingUse(BaseTest):
+    temp_db = __file__.replace(".py", ".db")
+
+    def test_threading_use(self):
+        stats = {"ok": 0, "error": 0}
+        sentinela = object()
+        cola: Queue[Any] = Queue(maxsize=5000)
+        lock = threading.Lock()
+
+        def worker(api_local: ContactoAppAPI[Any]):
+            while True:
+                telefono = cola.get()
+                if telefono is sentinela:
+                    cola.task_done()
+                    break
+                try:
+                    api_local.contacto.crear(TipoContacto.TELEFONO, telefono)
+                    with lock:
+                        stats["ok"] += 1
+                except Exception as e:
+                    with lock:
+                        stats["error"] += 1
+                        print(f"ERROR {telefono}: {e}")
+                finally:
+                    cola.task_done()
+
+        def main(api_local: ContactoAppAPI[Any], telefonos: list[str]):
+            n_hilos = 4
+
+            hilos = [
+                threading.Thread(target=worker, daemon=False, args=(api_local,))
+                for _ in range(n_hilos)
+            ]
+            for h in hilos:
+                h.start()
+
+            for telefono in telefonos:
+                cola.put(telefono)
+
+            for _ in hilos:
+                cola.put(sentinela)
+
+            cola.join()
+            for h in hilos:
+                h.join()
+
+            print(stats)
+
+        api_local = self.api_wrapper.contacto
+
+        telefonos = [
+            "+18090000000",
+            "+18090000080",
+            "+18090000088",
+            "+18090000135",
+            "+18090002552",
+            "+18090003263",
+            "+18090005002",
+            "+18090005545",
+            "+18090012012",
+            "+18090012121",
+        ]
+        main(api_local, telefonos)
+        assert stats["ok"] == len(telefonos)
+        assert stats["error"] == 0


### PR DESCRIPTION
## Summary
- replace SQLite `StaticPool` with `QueuePool` so concurrent tests use pooled connections instead of a single shared connection
- make transaction boundaries consistent by letting Unit of Work own commit/rollback when a UoW-managed connection is active
- add SQLite `PRAGMA busy_timeout` to reduce transient lock contention during concurrent writes

## Validation
- `uv run pytest src/tests/use_cases/test_threading_use.py -q`
- `uv run pytest src/tests/test_parallel_safe_scopes.py src/tests/test_parallel_dispatch_isolation.py -q`