### PR TITLE
fix: serialize outbox publishing per message bus instance

### DIFF
--- a/docs/how-to/migrate-to-0.3.0-scoped-execution.md
+++ b/docs/how-to/migrate-to-0.3.0-scoped-execution.md
@@ -160,6 +160,23 @@ These compatibility paths still exist, but treat them as bridges:
 
 They are there to reduce migration pain, not to define the future architecture.
 
+## Outbox single-writer boundary (important)
+
+`publish_from_outbox()` now has a single-writer guard with these limits:
+
+- exclusivity is **per `MessageBus` instance**
+- protection is **process-local** only
+
+What that means in practice:
+
+- two concurrent publish calls on the same bus instance are serialized
+- two different bus instances may publish in parallel
+- two different OS processes are **not** coordinated by this guard
+
+For multi-process deployments, if you need global single-consumer semantics, add a
+distributed claiming strategy (for example DB row claiming/leases or external
+distributed locks). That is intentionally out of scope for this runtime guard.
+
 ## Recommended rollout plan for clients
 
 1. keep your public API facade stable

--- a/src/hexagonal/adapters/drivens/buses/base/message_bus.py
+++ b/src/hexagonal/adapters/drivens/buses/base/message_bus.py
@@ -1,3 +1,4 @@
+import threading
 from abc import abstractmethod
 from typing import Any, Callable
 
@@ -24,6 +25,7 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
         self._outbox_repository_getter: (
             Callable[[Any], IOutboxRepository[TManager]] | None
         ) = None
+        self._outbox_publish_lock = threading.RLock()
         super().__init__()
 
     @property
@@ -53,12 +55,13 @@ class MessageBus(IBaseMessageBus[TManager], Infrastructure):
     # publish
     def publish_from_outbox(self, limit: int | None = None) -> None:
         self.verify()
-        self._run_with_outbox_repository(
-            lambda outbox_repository: self._publish_messages(
-                outbox_repository,
-                *outbox_repository.fetch_pending(limit=limit),
+        with self._outbox_publish_lock:
+            self._run_with_outbox_repository(
+                lambda outbox_repository: self._publish_messages(
+                    outbox_repository,
+                    *outbox_repository.fetch_pending(limit=limit),
+                )
             )
-        )
 
     def _run_with_outbox_repository(
         self,

--- a/src/tests/test_parallel_dispatch_isolation.py
+++ b/src/tests/test_parallel_dispatch_isolation.py
@@ -81,12 +81,12 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
     main_scope = runner.run_in_write_scope(
         lambda scope: (
             threading.get_ident(),
-            id(scope.uow),
-            id(scope.uow.connection_manager),
+            scope.uow,
+            scope.uow.connection_manager,
         )
     )
 
-    created_scopes: list[tuple[int, int, int]] = []
+    created_scopes: list[tuple[int, Any, Any]] = []
     original_create_write_scope = runner._create_write_scope
 
     def record_write_scope():
@@ -94,8 +94,8 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
         created_scopes.append(
             (
                 threading.get_ident(),
-                id(scope.uow),
-                id(scope.uow.connection_manager),
+                scope.uow,
+                scope.uow.connection_manager,
             )
         )
         return scope
@@ -136,8 +136,8 @@ def test_queued_command_worker_uses_an_isolated_write_scope_end_to_end(tmp_path:
         worker_scopes = [scope for scope in created_scopes if scope[0] != main_scope[0]]
 
         assert worker_scopes
-        assert all(scope[1] != main_scope[1] for scope in worker_scopes)
-        assert all(scope[2] != main_scope[2] for scope in worker_scopes)
+        assert all(scope[1] is not main_scope[1] for scope in worker_scopes)
+        assert all(scope[2] is not main_scope[2] for scope in worker_scopes)
     finally:
         runner._create_write_scope = original_create_write_scope
         command_bus.shutdown()
@@ -260,3 +260,128 @@ def test_queued_command_publish_from_outbox_uses_scoped_repository(tmp_path: Pat
         command_bus._publish_message = original_publish_message
         root_outbox.fetch_pending = original_root_fetch_pending
         root_outbox.mark_as_published = original_root_mark_as_published
+
+
+def test_concurrent_publish_from_outbox_on_same_bus_is_serialized(tmp_path: Path):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-dispatch-single-bus-serialized.db",
+        {
+            "ENV_BUS": "inmemory_queue",
+            "EVENT_BUS_WORKER_DAEMON": "false",
+        },
+    )
+
+    command_bus = cast(Any, app.command_bus)
+    contacto_api = api.contacto.contacto
+
+    response = contacto_api.crear(
+        TipoContacto.EMAIL.value,
+        "parallel-single-bus@example.com",
+        async_dispatch=True,
+    )
+    assert response.has_events is False
+
+    first_inside = threading.Event()
+    release_first = threading.Event()
+    active_cycles = 0
+    max_overlap = 0
+    published_ids: list[object] = []
+
+    original_run_with_outbox_repository = command_bus._run_with_outbox_repository
+    original_publish_message = command_bus._publish_message
+
+    def publish_message_noop(message):
+        published_ids.append(message.message_id)
+
+    def tracked_run_with_outbox_repository(work):
+        nonlocal active_cycles, max_overlap
+        active_cycles += 1
+        max_overlap = max(max_overlap, active_cycles)
+        if active_cycles == 1:
+            first_inside.set()
+            release_first.wait(timeout=2)
+        try:
+            return original_run_with_outbox_repository(work)
+        finally:
+            active_cycles -= 1
+
+    command_bus._publish_message = publish_message_noop
+    command_bus._run_with_outbox_repository = tracked_run_with_outbox_repository
+
+    try:
+        first_thread = threading.Thread(target=command_bus.publish_from_outbox)
+        second_thread = threading.Thread(target=command_bus.publish_from_outbox)
+
+        first_thread.start()
+        assert first_inside.wait(timeout=2)
+        second_thread.start()
+
+        # If serialization holds, second thread must still be waiting on the lock here.
+        assert second_thread.is_alive()
+        assert max_overlap == 1
+
+        release_first.set()
+        first_thread.join(timeout=2)
+        second_thread.join(timeout=2)
+    finally:
+        command_bus._publish_message = original_publish_message
+        command_bus._run_with_outbox_repository = original_run_with_outbox_repository
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert max_overlap == 1
+    assert len(set(published_ids)) == 1
+
+
+def test_publish_lock_scope_is_per_bus_instance(tmp_path: Path):
+    _, app, _ = bootstrap_example_stack(
+        tmp_path / "parallel-dispatch-per-bus-instance.db",
+        {
+            "ENV_BUS": "inmemory_queue",
+            "EVENT_BUS_WORKER_DAEMON": "false",
+        },
+    )
+
+    command_bus = cast(Any, app.command_bus)
+    event_bus = cast(Any, app.event_bus)
+
+    command_entered = threading.Event()
+    event_entered = threading.Event()
+    release_both = threading.Event()
+
+    original_command_run = command_bus._run_with_outbox_repository
+    original_event_run = event_bus._run_with_outbox_repository
+
+    def tracked_command_run(work):
+        command_entered.set()
+        release_both.wait(timeout=2)
+        return original_command_run(work)
+
+    def tracked_event_run(work):
+        event_entered.set()
+        release_both.wait(timeout=2)
+        return original_event_run(work)
+
+    command_bus._run_with_outbox_repository = tracked_command_run
+    event_bus._run_with_outbox_repository = tracked_event_run
+
+    try:
+        command_thread = threading.Thread(target=command_bus.publish_from_outbox)
+        event_thread = threading.Thread(target=event_bus.publish_from_outbox)
+
+        command_thread.start()
+        event_thread.start()
+
+        assert command_entered.wait(timeout=2)
+        assert event_entered.wait(timeout=2)
+
+        release_both.set()
+
+        command_thread.join(timeout=2)
+        event_thread.join(timeout=2)
+    finally:
+        command_bus._run_with_outbox_repository = original_command_run
+        event_bus._run_with_outbox_repository = original_event_run
+
+    assert not command_thread.is_alive()
+    assert not event_thread.is_alive()

--- a/src/tests/test_parallel_safe_scopes.py
+++ b/src/tests/test_parallel_safe_scopes.py
@@ -1,3 +1,4 @@
+import threading
 from pathlib import Path
 from typing import Any, cast
 
@@ -340,6 +341,136 @@ def test_publish_from_outbox_without_scope_runtime_falls_back_to_root_repository
 
     assert published_ids == [message.message_id]
     assert root_usage == ["fetch", "mark"]
+
+
+def test_publish_from_outbox_nested_same_thread_is_reentrant_and_no_deadlock(
+    tmp_path: Path,
+):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-safe-scope-nested-publish.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    contacto_api = api.contacto.contacto
+    created = contacto_api.crear(
+        TipoContacto.EMAIL.value,
+        "scope-nested-publish@example.com",
+    ).get(contacto_api.Events.CREADO.value)
+    message = CloudMessage[type(created)].new(created)
+
+    event_bus = cast(Any, app.event_bus)
+    event_bus.configure_scope_runtime()
+    root_outbox = event_bus.outbox_repository
+    publish_calls: list[object] = []
+    mark_calls: list[object] = []
+    fetch_calls: list[str] = []
+    nested_triggered = False
+
+    original_publish_message = event_bus._publish_message
+    original_fetch_pending = root_outbox.fetch_pending
+    original_mark_as_published = root_outbox.mark_as_published
+
+    def fetch_pending(*args: Any, **kwargs: Any):
+        fetch_calls.append("fetch")
+        if len(fetch_calls) == 1:
+            return [message]
+        return []
+
+    def mark_as_published(*message_ids: Any):
+        mark_calls.extend(message_ids)
+
+    def nested_publish_once(cloud_message: CloudMessage[Any]):
+        nonlocal nested_triggered
+        publish_calls.append(cloud_message.message_id)
+        if not nested_triggered:
+            nested_triggered = True
+            event_bus.publish_from_outbox(limit=1)
+
+    root_outbox.fetch_pending = fetch_pending
+    root_outbox.mark_as_published = mark_as_published
+    event_bus._publish_message = nested_publish_once
+
+    try:
+        event_bus.publish_from_outbox(limit=1)
+    finally:
+        root_outbox.fetch_pending = original_fetch_pending
+        root_outbox.mark_as_published = original_mark_as_published
+        event_bus._publish_message = original_publish_message
+
+    assert nested_triggered is True
+    assert fetch_calls == ["fetch", "fetch"]
+    assert publish_calls == [message.message_id]
+    assert mark_calls == [message.message_id]
+
+
+def test_publish_from_outbox_releases_lock_after_failure_for_retry_attempt(
+    tmp_path: Path,
+):
+    _, app, api = bootstrap_example_stack(
+        tmp_path / "parallel-safe-scope-publish-failure-retry.db",
+        {"ENV_BUS": "inmemory"},
+    )
+
+    contacto_api = api.contacto.contacto
+    created = contacto_api.crear(
+        TipoContacto.EMAIL.value,
+        "scope-publish-failure-retry@example.com",
+    ).get(contacto_api.Events.CREADO.value)
+    message = CloudMessage[type(created)].new(created)
+
+    event_bus = cast(Any, app.event_bus)
+    event_bus.configure_scope_runtime()
+    root_outbox = event_bus.outbox_repository
+    failure_errors: list[str] = []
+    published_ids: list[object] = []
+    publish_attempts = 0
+
+    original_publish_message = event_bus._publish_message
+    original_fetch_pending = root_outbox.fetch_pending
+    original_mark_as_failed = root_outbox.mark_as_failed
+    original_mark_as_published = root_outbox.mark_as_published
+
+    def fetch_pending(*args: Any, **kwargs: Any):
+        return [message]
+
+    def mark_as_failed(*message_ids: Any, error: str):
+        failure_errors.append(error)
+
+    def mark_as_published(*message_ids: Any):
+        published_ids.extend(message_ids)
+
+    def fail_then_succeed(cloud_message: CloudMessage[Any]):
+        nonlocal publish_attempts
+        publish_attempts += 1
+        if publish_attempts == 1:
+            raise RuntimeError("first-attempt-failure")
+
+    root_outbox.fetch_pending = fetch_pending
+    root_outbox.mark_as_failed = mark_as_failed
+    root_outbox.mark_as_published = mark_as_published
+    event_bus._publish_message = fail_then_succeed
+
+    retry_done = threading.Event()
+
+    def retry_publish() -> None:
+        event_bus.publish_from_outbox(limit=1)
+        retry_done.set()
+
+    try:
+        event_bus.publish_from_outbox(limit=1)
+        retry_thread = threading.Thread(target=retry_publish)
+        retry_thread.start()
+        retry_thread.join(timeout=2)
+    finally:
+        root_outbox.fetch_pending = original_fetch_pending
+        root_outbox.mark_as_failed = original_mark_as_failed
+        root_outbox.mark_as_published = original_mark_as_published
+        event_bus._publish_message = original_publish_message
+
+    assert retry_done.is_set()
+    assert publish_attempts == 2
+    assert failure_errors == ["first-attempt-failure"]
+    assert published_ids == [message.message_id]
 
 
 def test_read_scopes_create_fresh_managers_and_repositories(tmp_path: Path):


### PR DESCRIPTION
## Summary
- serialize `publish_from_outbox()` per `MessageBus` instance using a re-entrant lock to avoid overlapping publish cycles
- add concurrency and re-entrancy regression tests for same-bus serialization, per-instance lock scope, and failure-path lock release
- document the guarantee boundary: process-local/per-instance (not distributed coordination)

## Validation
- `uv run pytest src/tests/test_parallel_safe_scopes.py src/tests/test_parallel_dispatch_isolation.py -q`
- SDD lifecycle completed for `outbox-single-writer` (`explore -> propose -> spec -> design -> tasks -> apply -> verify -> archive`)